### PR TITLE
Fix incorrect handling of polyfills

### DIFF
--- a/src/Anthropic.Foundry/Anthropic.Foundry.csproj
+++ b/src/Anthropic.Foundry/Anthropic.Foundry.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
     <PackageReference Include="Azure.Identity" Version="1.17.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+  </ItemGroup>
   <PropertyGroup>
     <BuildPackage>true</BuildPackage>
     <Deterministic>true</Deterministic>
@@ -39,9 +43,6 @@
     <SupportedFrameworks>net8.0;net9.0;netstandard2.0</SupportedFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../Anthropic/GlobalShims.cs">
-      <Link>%(RecursiveDir)/%(FileName)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <Compile Include="../Anthropic/GlobalShims.cs" />
   </ItemGroup>
 </Project>

--- a/src/Anthropic.Foundry/AnthropicFoundryClient.cs
+++ b/src/Anthropic.Foundry/AnthropicFoundryClient.cs
@@ -1,9 +1,4 @@
-#if NETSTANDARD2_0
-global using ValueTask = System.Threading.Tasks.Task;
 using Anthropic.Core;
-#else
-using Anthropic.Core;
-#endif
 
 namespace Anthropic.Foundry;
 
@@ -65,6 +60,6 @@ public class AnthropicFoundryClient : AnthropicClient
     {
         _azureCredentials.Apply(requestMessage);
 
-        return ValueTask.CompletedTask;
+        return default;
     }
 }

--- a/src/Anthropic/Anthropic.csproj
+++ b/src/Anthropic/Anthropic.csproj
@@ -61,4 +61,7 @@
     <PackageReference Include="System.Text.Json" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.0.0" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Anthropic/AnthropicClient.cs
+++ b/src/Anthropic/AnthropicClient.cs
@@ -153,7 +153,7 @@ public class AnthropicClient : IAnthropicClient
     )
         where T : ParamsBase
     {
-        return ValueTask.CompletedTask;
+        return default;
     }
 
     protected virtual ValueTask AfterSend<T>(
@@ -163,7 +163,7 @@ public class AnthropicClient : IAnthropicClient
     )
         where T : ParamsBase
     {
-        return ValueTask.CompletedTask;
+        return default;
     }
 
     async Task<HttpResponse> ExecuteOnce<T>(

--- a/src/Anthropic/GlobalShims.cs
+++ b/src/Anthropic/GlobalShims.cs
@@ -1,39 +1,18 @@
 // This file provides minimal compatibility shims for types not available
-// when targeting .NET Standard 2.0. The definitions are intentionally
-// small — they forward to `Task` where appropriate so the library can
-// compile under netstandard2.0 while remaining source-compatible with
-// newer frameworks.
+// when targeting .NET Standard 2.0.
 
-#if NETSTANDARD2_0
-global using ValueTask = System.Threading.Tasks.Task;
+#if !NET
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Text.Json;
 
-/* ValueTask and related async interface types are provided by
-   referenced compatibility packages (e.g. System.Threading.Tasks.Extensions,
-   Microsoft.Bcl.AsyncInterfaces). Defining them here can conflict with
-   those packages, so we do not provide ValueTask/IAsync* shims in this file. */
-
-/* IAsyncDisposable is provided by compatibility packages on netstandard2.0
-   targets; avoid redefining it here to prevent type conflicts. */
-
-/* IAsyncEnumerable/IAsyncEnumerator are supplied by Microsoft.Bcl.AsyncInterfaces
-   when the project references it; redefining them causes conflicts, so
-   they are omitted here. */
-
-#if !NET5_0_OR_GREATER
 namespace System.Runtime.CompilerServices
 {
     // Shim to enable `init` accessors when compiling against older targets.
-    // The compiler looks for the `IsExternalInit` type; an empty public
-    // static class is sufficient as a placeholder.
-    public static class IsExternalInit { }
+    // The compiler looks for the `IsExternalInit` type
+    internal static class IsExternalInit { }
 
     // Supports `required` members feature: marks members that must be
     // initialized during object construction.
@@ -45,15 +24,14 @@ namespace System.Runtime.CompilerServices
             | AttributeTargets.Event,
         Inherited = false
     )]
-    public sealed class RequiredMemberAttribute : Attribute { }
+    internal sealed class RequiredMemberAttribute : Attribute { }
 
     // Applied to constructors (or factory methods) that ensure required
     // members are set. Compiler recognizes this attribute when analyzing
     // object initialization for `required` members.
     [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false)]
-    public sealed class SetsRequiredMembersAttribute : Attribute { }
+    internal sealed class SetsRequiredMembersAttribute : Attribute { }
 }
-#endif
 
 // Additional shims required by generated model code when compiling
 // against netstandard2.0. These are minimal stubs that provide the
@@ -61,7 +39,7 @@ namespace System.Runtime.CompilerServices
 namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = false)]
-    public sealed class CompilerFeatureRequiredAttribute : Attribute
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
     {
         public CompilerFeatureRequiredAttribute(string feature)
         {
@@ -75,7 +53,7 @@ namespace System.Runtime.CompilerServices
 namespace System.Diagnostics.CodeAnalysis
 {
     [AttributeUsage(AttributeTargets.Constructor | AttributeTargets.Method, Inherited = false)]
-    public sealed class SetsRequiredMembersAttribute : Attribute
+    internal sealed class SetsRequiredMembersAttribute : Attribute
     {
         public SetsRequiredMembersAttribute() { }
     }
@@ -88,180 +66,36 @@ namespace System.Diagnostics.CodeAnalysis
             | AttributeTargets.Event,
         Inherited = false
     )]
-    public sealed class RequiredMemberAttribute : Attribute
+    internal sealed class RequiredMemberAttribute : Attribute
     {
         public RequiredMemberAttribute() { }
     }
 
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    public sealed class NotNullWhenAttribute : Attribute
+    internal sealed class NotNullWhenAttribute : Attribute
     {
         public NotNullWhenAttribute(bool returnValue) { }
-    }
-}
-
-namespace System.Collections.Generic
-{
-    // Intentionally left empty: prefer the `System.Collections.Frozen.FrozenDictionary`
-    // shim below. Avoid defining `FrozenDictionary` in `System.Collections.Generic`
-    // to prevent ambiguous type references when generated code imports both
-    // `System.Collections` and `System.Collections.Frozen`.
-}
-
-namespace System.Collections.Frozen
-{
-    // Provide a FrozenDictionary in the System.Collections.Frozen namespace
-    // to match usages of that API in generated code.
-    public class FrozenDictionary<TKey, TValue>
-        : System.Collections.Generic.Dictionary<TKey, TValue>
-    {
-        public FrozenDictionary()
-            : base() { }
-
-        public FrozenDictionary(System.Collections.Generic.IDictionary<TKey, TValue> source)
-            : base(source) { }
-
-        public static FrozenDictionary<TKey, TValue> ToFrozenDictionary(
-            System.Collections.Generic.IDictionary<TKey, TValue> source
-        )
-        {
-            if (source is FrozenDictionary<TKey, TValue> fd)
-                return fd;
-            return new FrozenDictionary<TKey, TValue>(source);
-        }
-    }
-
-    // Provide a FrozenDictionary in the System.Collections.Frozen namespace
-    // to match usages of that API in generated code.
-    public class FrozenDictionary
-    {
-        public static FrozenDictionary<TKey, TValue> ToFrozenDictionary<TKey, TValue>(
-            System.Collections.Generic.IDictionary<TKey, TValue> source
-        )
-        {
-            if (source is FrozenDictionary<TKey, TValue> fd)
-                return fd;
-            return new FrozenDictionary<TKey, TValue>(source);
-        }
-
-        public static FrozenDictionary<TKey, TValue> ToFrozenDictionary<TKey, TValue>(
-            System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> source
-        )
-        {
-            if (source is FrozenDictionary<TKey, TValue> fd)
-                return fd;
-            return new FrozenDictionary<TKey, TValue>(
-                source.ToDictionary(e => e.Key, e => e.Value)
-            );
-        }
-    }
-}
-
-namespace System.Collections.Immutable
-{
-    // Marker type so the `System.Collections.Immutable` namespace exists
-    // for files that `using` it but do not require concrete immutable types
-    public static class _NamespaceMarker { }
-
-    public interface IImmutableList<T> : System.Collections.Generic.IReadOnlyList<T> { }
-
-    public class ImmutableArray<T> : IImmutableList<T>
-    {
-        private readonly T[] _array;
-
-        public ImmutableArray(T[] array)
-        {
-            _array = array;
-        }
-
-        public T this[int index] => _array[index];
-
-        public int Count => _array.Length;
-
-        public System.Collections.Generic.IEnumerator<T> GetEnumerator()
-        {
-            foreach (var item in _array)
-            {
-                yield return item;
-            }
-        }
-
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        public static ImmutableArray<T> ToImmutableArray(
-            System.Collections.Generic.IEnumerable<T> source
-        )
-        {
-            return new ImmutableArray<T>(source.ToArray());
-        }
-    }
-
-    public class ImmutableArray
-    {
-        public static ImmutableArray<T> ToImmutableArray<T>(
-            System.Collections.Generic.IEnumerable<T> source
-        )
-        {
-            return ImmutableArray<T>.ToImmutableArray(source);
-        }
     }
 }
 
 namespace System.Diagnostics.CodeAnalysis
 {
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    public sealed class MaybeNullWhenAttribute : Attribute
+    internal sealed class MaybeNullWhenAttribute : Attribute
     {
         public MaybeNullWhenAttribute(bool returnValue) { }
     }
 
     [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
-    public sealed class MaybeNullAttribute : Attribute
+    internal sealed class MaybeNullAttribute : Attribute
     {
         public MaybeNullAttribute() { }
     }
 }
-
-public static class ModelConverterConstructionShim
-{
-    public const string FromRawUncheckedMethodName = "FromRawUnchecked";
-
-    static ModelConverterConstructionShim()
-    {
-        Assembly
-            .GetCallingAssembly()
-            .GetTypes()
-            .Where(t => t.IsSubclassOf(typeof(Anthropic.Core.ModelBase)))
-            .ToList()
-            .ForEach(t =>
-            {
-                var converterType = typeof(Anthropic.Core.ModelConverter<>).MakeGenericType(t);
-                var converterMethod = converterType.GetMethod(
-                    FromRawUncheckedMethodName,
-                    BindingFlags.Static | BindingFlags.Public
-                );
-                if (converterMethod is null)
-                {
-                    return;
-                }
-                var fromRaw =
-                    (Func<IReadOnlyDictionary<string, JsonElement>, object>)
-                        Delegate.CreateDelegate(
-                            typeof(Func<IReadOnlyDictionary<string, JsonElement>, object>),
-                            converterMethod
-                        );
-                FromRawFactories.Add(t, fromRaw);
-            });
-    }
-
-    internal static Dictionary<
-        Type,
-        Func<IReadOnlyDictionary<string, JsonElement>, object>
-    > FromRawFactories { get; } =
-        new Dictionary<Type, Func<IReadOnlyDictionary<string, JsonElement>, object>>();
-}
-
+#else
+// The compiler emits a reference to the internal copy of this type in the non-.NET builds,
+// so we must include a forward to be compatible.
+[assembly: System.Runtime.CompilerServices.TypeForwardedTo(
+    typeof(System.Runtime.CompilerServices.IsExternalInit)
+)]
 #endif


### PR DESCRIPTION
- The System.Runtime.CompilerServices / System.Diagnostics.CodeAnalysis types should all be internal rather than public; otherwise they will lead to ambiguity warnings with consumers and also won't type unify.
- The System.Collection.Immutable / ValueTask types should not be polyfilled; they instead should just use the netstandard2.0 packages.
- Anthropic.Foundry needs to include the shims.cs file correctly.

cc: @sd-st, @rogerbarreto