### PR TITLE
Add CodeExecution2025_08_25 to AnthropicBeta enum

### DIFF
--- a/src/Anthropic/Models/Beta/AnthropicBeta.cs
+++ b/src/Anthropic/Models/Beta/AnthropicBeta.cs
@@ -22,6 +22,7 @@ public enum AnthropicBeta
     DevFullThinking2025_05_14,
     InterleavedThinking2025_05_14,
     CodeExecution2025_05_22,
+    CodeExecution2025_08_25,
     ExtendedCacheTTL2025_04_11,
     Context1m2025_08_07,
     ContextManagement2025_06_27,
@@ -52,7 +53,8 @@ sealed class AnthropicBetaConverter : JsonConverter<AnthropicBeta>
             "mcp-client-2025-11-20" => AnthropicBeta.MCPClient2025_11_20,
             "dev-full-thinking-2025-05-14" => AnthropicBeta.DevFullThinking2025_05_14,
             "interleaved-thinking-2025-05-14" => AnthropicBeta.InterleavedThinking2025_05_14,
-            "code-execution-2025-05-22" => AnthropicBeta.CodeExecution2025_05_22,
+            "code-execution-2025-05-22" => AnthropicBeta.CodeExecution2025_05_22,            
+            "code-execution-2025-08-25" => AnthropicBeta.CodeExecution2025_08_25,
             "extended-cache-ttl-2025-04-11" => AnthropicBeta.ExtendedCacheTTL2025_04_11,
             "context-1m-2025-08-07" => AnthropicBeta.Context1m2025_08_07,
             "context-management-2025-06-27" => AnthropicBeta.ContextManagement2025_06_27,
@@ -86,7 +88,8 @@ sealed class AnthropicBetaConverter : JsonConverter<AnthropicBeta>
                 AnthropicBeta.MCPClient2025_11_20 => "mcp-client-2025-11-20",
                 AnthropicBeta.DevFullThinking2025_05_14 => "dev-full-thinking-2025-05-14",
                 AnthropicBeta.InterleavedThinking2025_05_14 => "interleaved-thinking-2025-05-14",
-                AnthropicBeta.CodeExecution2025_05_22 => "code-execution-2025-05-22",
+                AnthropicBeta.CodeExecution2025_05_22 => "code-execution-2025-05-22",                
+                AnthropicBeta.CodeExecution2025_08_25 => "code-execution-2025-08-25",
                 AnthropicBeta.ExtendedCacheTTL2025_04_11 => "extended-cache-ttl-2025-04-11",
                 AnthropicBeta.Context1m2025_08_07 => "context-1m-2025-08-07",
                 AnthropicBeta.ContextManagement2025_06_27 => "context-management-2025-06-27",
@@ -101,3 +104,4 @@ sealed class AnthropicBetaConverter : JsonConverter<AnthropicBeta>
         );
     }
 }
+

--- a/src/Anthropic/Models/Beta/AnthropicBeta.cs
+++ b/src/Anthropic/Models/Beta/AnthropicBeta.cs
@@ -22,12 +22,12 @@ public enum AnthropicBeta
     DevFullThinking2025_05_14,
     InterleavedThinking2025_05_14,
     CodeExecution2025_05_22,
-    CodeExecution2025_08_25,
     ExtendedCacheTTL2025_04_11,
     Context1m2025_08_07,
     ContextManagement2025_06_27,
     ModelContextWindowExceeded2025_08_26,
-    Skills2025_10_02,
+    Skills2025_10_02,    
+    CodeExecution2025_08_25,
 }
 
 sealed class AnthropicBetaConverter : JsonConverter<AnthropicBeta>
@@ -104,4 +104,5 @@ sealed class AnthropicBetaConverter : JsonConverter<AnthropicBeta>
         );
     }
 }
+
 


### PR DESCRIPTION
Added a new enum value for CodeExecution2025_08_25 in AnthropicBeta. Only the legacy `code_execution_2025052` is present currently. This causes an error when trying to use the new code execution tool (as mapped by HostedCodeInterpreterTool in the MEAI extensions), as the legacy header only allows the legacy code execution tool.

```csharp
var options = new ChatOptions
        {
            ModelId = modelName,
            MaxOutputTokens = maxTokens,
            Temperature = 1
            Tools = [new HostedCodeInterpreterTool()]
        };
        
options.RawRepresentationFactory = _ => new MessageCreateParams
            {
                Model = modelName,
                MaxTokens = maxTokens,
                Messages = [],
                Betas = [AnthropicBeta.CodeExecution2025_05_22]
            };
```
The above causes an error from the API as there's no way to pass the correct beta header, and the legacy one won't enable the new server tool.

Ref: https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool

Fixes #45 