### PR TITLE
Fix handling of multiple streaming tool calls

### DIFF
--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -357,6 +357,8 @@ public static class AnthropicClientExtensions
                                     )
                                 );
                             }
+
+                            streamingFunctions.Clear();
                         }
                         break;
                 }

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -392,6 +392,8 @@ public static class AnthropicBetaClientExtensions
                                     )
                                 );
                             }
+
+                            streamingFunctions.Clear();
                         }
                         break;
                 }


### PR DESCRIPTION
The implementation was missing a clear on the collection of streaming data. As such, it would yield each tool already yielded every time it yielded another tool.

Fixes https://github.com/anthropics/anthropic-sdk-csharp/issues/53