### PR TITLE
Improve reporting of token counts in UsageDetails

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -1290,8 +1290,9 @@ public abstract class AnthropicClientExtensionsTestsBase
         Assert.NotNull(response);
 
         Assert.NotNull(response.Usage);
-        Assert.Equal(100, response.Usage.InputTokenCount);
+        Assert.Equal(175, response.Usage.InputTokenCount);
         Assert.Equal(10, response.Usage.OutputTokenCount);
+        Assert.Equal(185, response.Usage.TotalTokenCount);
         Assert.NotNull(response.Usage.AdditionalCounts);
         Assert.Equal(50L, response.Usage.AdditionalCounts["CacheCreationInputTokens"]);
         Assert.Equal(25L, response.Usage.AdditionalCounts["CacheReadInputTokens"]);
@@ -2490,8 +2491,9 @@ public abstract class AnthropicClientExtensionsTestsBase
         Assert.NotNull(response);
 
         Assert.NotNull(response.Usage);
-        Assert.Equal(100, response.Usage.InputTokenCount);
+        Assert.Equal(175, response.Usage.InputTokenCount);
         Assert.Equal(20, response.Usage.OutputTokenCount);
+        Assert.Equal(195, response.Usage.OutputTokenCount);
         Assert.NotNull(response.Usage.AdditionalCounts);
         Assert.Equal(50L, response.Usage.AdditionalCounts["CacheCreationInputTokens"]);
         Assert.Equal(25L, response.Usage.AdditionalCounts["CacheReadInputTokens"]);

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -926,17 +926,18 @@ public static class AnthropicClientExtensions
             ServerToolUsage? serverToolUsage
         )
         {
-            UsageDetails usageDetails = new();
+            UsageDetails usageDetails = new()
+            {
+                // From https://platform.claude.com/docs/en/build-with-claude/prompt-caching:
+                // "To calculate total input tokens:"
+                // "total_input_tokens = cache_read_input_tokens + cache_creation_input_tokens + input_tokens"
+                InputTokenCount = NullableSum(
+                    NullableSum(cacheReadInputTokens, cacheCreationInputTokens),
+                    inputTokens
+                ),
 
-            // From https://platform.claude.com/docs/en/build-with-claude/prompt-caching:
-            // "To calculate total input tokens:"
-            // "total_input_tokens = cache_read_input_tokens + cache_creation_input_tokens + input_tokens"
-            usageDetails.InputTokenCount = NullableSum(
-                NullableSum(cacheReadInputTokens, cacheCreationInputTokens),
-                inputTokens
-            );
-
-            usageDetails.OutputTokenCount = outputTokens;
+                OutputTokenCount = outputTokens
+            };
 
             usageDetails.TotalTokenCount = NullableSum(
                 usageDetails.InputTokenCount,

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -936,7 +936,7 @@ public static class AnthropicClientExtensions
                     inputTokens
                 ),
 
-                OutputTokenCount = outputTokens
+                OutputTokenCount = outputTokens,
             };
 
             usageDetails.TotalTokenCount = NullableSum(

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1174,17 +1174,18 @@ public static class AnthropicBetaClientExtensions
             BetaServerToolUsage? serverToolUsage
         )
         {
-            UsageDetails usageDetails = new();
+            UsageDetails usageDetails = new()
+            {
+                // From https://platform.claude.com/docs/en/build-with-claude/prompt-caching:
+                // "To calculate total input tokens:"
+                // "total_input_tokens = cache_read_input_tokens + cache_creation_input_tokens + input_tokens"
+                InputTokenCount = NullableSum(
+                    NullableSum(cacheReadInputTokens, cacheCreationInputTokens),
+                    inputTokens
+                ),
 
-            // From https://platform.claude.com/docs/en/build-with-claude/prompt-caching:
-            // "To calculate total input tokens:"
-            // "total_input_tokens = cache_read_input_tokens + cache_creation_input_tokens + input_tokens"
-            usageDetails.InputTokenCount = NullableSum(
-                NullableSum(cacheReadInputTokens, cacheCreationInputTokens),
-                inputTokens
-            );
-
-            usageDetails.OutputTokenCount = outputTokens;
+                OutputTokenCount = outputTokens
+            };
 
             usageDetails.TotalTokenCount = NullableSum(
                 usageDetails.InputTokenCount,

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1153,7 +1153,8 @@ public static class AnthropicBetaClientExtensions
                 usage.InputTokens,
                 usage.OutputTokens,
                 usage.CacheCreationInputTokens,
-                usage.CacheReadInputTokens
+                usage.CacheReadInputTokens,
+                usage.ServerToolUse
             );
 
         private static UsageDetails ToUsageDetails(BetaMessageDeltaUsage usage) =>
@@ -1161,39 +1162,65 @@ public static class AnthropicBetaClientExtensions
                 usage.InputTokens,
                 usage.OutputTokens,
                 usage.CacheCreationInputTokens,
-                usage.CacheReadInputTokens
+                usage.CacheReadInputTokens,
+                usage.ServerToolUse
             );
 
         private static UsageDetails ToUsageDetails(
             long? inputTokens,
             long? outputTokens,
             long? cacheCreationInputTokens,
-            long? cacheReadInputTokens
+            long? cacheReadInputTokens,
+            BetaServerToolUsage? serverToolUsage
         )
         {
-            UsageDetails usageDetails = new()
-            {
-                InputTokenCount = inputTokens,
-                OutputTokenCount = outputTokens,
-                TotalTokenCount =
-                    (inputTokens is not null || outputTokens is not null)
-                        ? (inputTokens ?? 0) + (outputTokens ?? 0)
-                        : null,
-            };
+            UsageDetails usageDetails = new();
 
-            if (cacheCreationInputTokens is not null)
+            // From https://platform.claude.com/docs/en/build-with-claude/prompt-caching:
+            // "To calculate total input tokens:"
+            // "total_input_tokens = cache_read_input_tokens + cache_creation_input_tokens + input_tokens"
+            usageDetails.InputTokenCount = NullableSum(
+                NullableSum(cacheReadInputTokens, cacheCreationInputTokens),
+                inputTokens
+            );
+
+            usageDetails.OutputTokenCount = outputTokens;
+
+            usageDetails.TotalTokenCount = NullableSum(
+                usageDetails.InputTokenCount,
+                usageDetails.OutputTokenCount
+            );
+
+            if (cacheCreationInputTokens is > 0)
             {
                 (usageDetails.AdditionalCounts ??= [])[nameof(BetaUsage.CacheCreationInputTokens)] =
                     cacheCreationInputTokens.Value;
             }
 
-            if (cacheReadInputTokens is not null)
+            if (cacheReadInputTokens is > 0)
             {
                 (usageDetails.AdditionalCounts ??= [])[nameof(BetaUsage.CacheReadInputTokens)] =
                     cacheReadInputTokens.Value;
             }
 
+            if (serverToolUsage?.WebFetchRequests is > 0)
+            {
+                (usageDetails.AdditionalCounts ??= [])[
+                    nameof(BetaServerToolUsage.WebFetchRequests)
+                ] = serverToolUsage.WebFetchRequests;
+            }
+
+            if (serverToolUsage?.WebSearchRequests is > 0)
+            {
+                (usageDetails.AdditionalCounts ??= [])[
+                    nameof(BetaServerToolUsage.WebSearchRequests)
+                ] = serverToolUsage.WebSearchRequests;
+            }
+
             return usageDetails;
+
+            static long? NullableSum(long? a, long? b) =>
+                a is not null || b is not null ? (a ?? 0) + (b ?? 0) : null;
         }
 
         private static ChatFinishReason? ToFinishReason(

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1184,7 +1184,7 @@ public static class AnthropicBetaClientExtensions
                     inputTokens
                 ),
 
-                OutputTokenCount = outputTokens
+                OutputTokenCount = outputTokens,
             };
 
             usageDetails.TotalTokenCount = NullableSum(


### PR DESCRIPTION
- InputTokenCount needs to reflect cached tokens.
- Only add to AdditionalCounts for positive counts.
- Added reporting of WebFetch/SearchRequests.