### PR TITLE
Fix build warnings in next

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/examples/MessagesExample/Program.cs
+++ b/examples/MessagesExample/Program.cs
@@ -19,12 +19,11 @@ MessageCreateParams parameters = new()
 
 var response = await client.Messages.Create(parameters);
 
-var message = string.Join(
-    "",
+var message = string.Concat(
     response
         .Content.Where(message => message.Value is TextBlock)
         .Select(message => message.Value as TextBlock)
-        .Select((textBlock) => textBlock.Text)
+        .Select((textBlock) => textBlock?.Text ?? "")
 );
 
 Console.WriteLine(message);

--- a/src/Anthropic.Tests/Models/Beta/Messages/Batches/BatchCreateParamsTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/Batches/BatchCreateParamsTest.cs
@@ -1359,6 +1359,7 @@ public class ParamsTest : TestBase
         Assert.Equal(expectedModel, deserialized.Model);
         Assert.Equal(expectedContainer, deserialized.Container);
         Assert.Equal(expectedContextManagement, deserialized.ContextManagement);
+        Assert.NotNull(deserialized.MCPServers);
         Assert.Equal(expectedMCPServers.Count, deserialized.MCPServers.Count);
         for (int i = 0; i < expectedMCPServers.Count; i++)
         {
@@ -1368,6 +1369,7 @@ public class ParamsTest : TestBase
         Assert.Equal(expectedOutputConfig, deserialized.OutputConfig);
         Assert.Equal(expectedOutputFormat, deserialized.OutputFormat);
         Assert.Equal(expectedServiceTier, deserialized.ServiceTier);
+        Assert.NotNull(deserialized.StopSequences);
         Assert.Equal(expectedStopSequences.Count, deserialized.StopSequences.Count);
         for (int i = 0; i < expectedStopSequences.Count; i++)
         {
@@ -1378,6 +1380,7 @@ public class ParamsTest : TestBase
         Assert.Equal(expectedTemperature, deserialized.Temperature);
         Assert.Equal(expectedThinking, deserialized.Thinking);
         Assert.Equal(expectedToolChoice, deserialized.ToolChoice);
+        Assert.NotNull(deserialized.Tools);
         Assert.Equal(expectedTools.Count, deserialized.Tools.Count);
         for (int i = 0; i < expectedTools.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaClearThinking20251015EditTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaClearThinking20251015EditTest.cs
@@ -115,6 +115,7 @@ public class UnionMember2Test : TestBase
         var constant = JsonSerializer.Deserialize<UnionMember2>(
             JsonSerializer.Deserialize<JsonElement>("\"all\"")
         );
+        Assert.NotNull(constant);
         constant.Validate();
     }
 
@@ -124,6 +125,7 @@ public class UnionMember2Test : TestBase
         var constant = JsonSerializer.Deserialize<UnionMember2>(
             JsonSerializer.Deserialize<JsonElement>("\"invalid value\"")
         );
+        Assert.NotNull(constant);
         Assert.Throws<AnthropicInvalidDataException>(() => constant.Validate());
     }
 

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaClearToolUses20250919EditTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaClearToolUses20250919EditTest.cs
@@ -85,6 +85,7 @@ public class BetaClearToolUses20250919EditTest : TestBase
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
         Assert.Equal(expectedClearAtLeast, deserialized.ClearAtLeast);
         Assert.Equal(expectedClearToolInputs, deserialized.ClearToolInputs);
+        Assert.NotNull(deserialized.ExcludeTools);
         Assert.Equal(expectedExcludeTools.Count, deserialized.ExcludeTools.Count);
         for (int i = 0; i < expectedExcludeTools.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaCodeExecutionTool20250522Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaCodeExecutionTool20250522Test.cs
@@ -82,6 +82,7 @@ public class BetaCodeExecutionTool20250522Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaCodeExecutionTool20250825Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaCodeExecutionTool20250825Test.cs
@@ -88,6 +88,7 @@ public class BetaCodeExecutionTool20250825Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaContainerParamsTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaContainerParamsTest.cs
@@ -98,6 +98,7 @@ public class BetaContainerParamsTest : TestBase
         ];
 
         Assert.Equal(expectedID, deserialized.ID);
+        Assert.NotNull(deserialized.Skills);
         Assert.Equal(expectedSkills.Count, deserialized.Skills.Count);
         for (int i = 0; i < expectedSkills.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaContainerTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaContainerTest.cs
@@ -106,6 +106,7 @@ public class BetaContainerTest : TestBase
 
         Assert.Equal(expectedID, deserialized.ID);
         Assert.Equal(expectedExpiresAt, deserialized.ExpiresAt);
+        Assert.NotNull(deserialized.Skills);
         Assert.Equal(expectedSkills.Count, deserialized.Skills.Count);
         for (int i = 0; i < expectedSkills.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaContextManagementConfigTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaContextManagementConfigTest.cs
@@ -101,6 +101,7 @@ public class BetaContextManagementConfigTest : TestBase
             },
         ];
 
+        Assert.NotNull(deserialized.Edits);
         Assert.Equal(expectedEdits.Count, deserialized.Edits.Count);
         for (int i = 0; i < expectedEdits.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaMCPToolsetTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaMCPToolsetTest.cs
@@ -115,6 +115,7 @@ public class BetaMCPToolsetTest : TestBase
         Assert.Equal(expectedMCPServerName, deserialized.MCPServerName);
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
+        Assert.NotNull(deserialized.Configs);
         Assert.Equal(expectedConfigs.Count, deserialized.Configs.Count);
         foreach (var item in expectedConfigs)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaMemoryTool20250818Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaMemoryTool20250818Test.cs
@@ -130,6 +130,7 @@ public class BetaMemoryTool20250818Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -137,6 +138,7 @@ public class BetaMemoryTool20250818Test : TestBase
         }
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaMemoryTool20250818ViewCommandTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaMemoryTool20250818ViewCommandTest.cs
@@ -62,6 +62,7 @@ public class BetaMemoryTool20250818ViewCommandTest : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedCommand, deserialized.Command));
         Assert.Equal(expectedPath, deserialized.Path);
+        Assert.NotNull(deserialized.ViewRange);
         Assert.Equal(expectedViewRange.Count, deserialized.ViewRange.Count);
         for (int i = 0; i < expectedViewRange.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaMessageTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaMessageTest.cs
@@ -119,7 +119,7 @@ public class BetaMessageTest : TestBase
         JsonElement expectedRole = JsonSerializer.Deserialize<JsonElement>("\"assistant\"");
         ApiEnum<string, Messages::BetaStopReason> expectedStopReason =
             Messages::BetaStopReason.EndTurn;
-        string expectedStopSequence = null;
+        string? expectedStopSequence = null;
         JsonElement expectedType = JsonSerializer.Deserialize<JsonElement>("\"message\"");
         Messages::BetaUsage expectedUsage = new()
         {
@@ -331,7 +331,7 @@ public class BetaMessageTest : TestBase
         JsonElement expectedRole = JsonSerializer.Deserialize<JsonElement>("\"assistant\"");
         ApiEnum<string, Messages::BetaStopReason> expectedStopReason =
             Messages::BetaStopReason.EndTurn;
-        string expectedStopSequence = null;
+        string? expectedStopSequence = null;
         JsonElement expectedType = JsonSerializer.Deserialize<JsonElement>("\"message\"");
         Messages::BetaUsage expectedUsage = new()
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaRequestMCPServerToolConfigurationTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaRequestMCPServerToolConfigurationTest.cs
@@ -57,6 +57,7 @@ public class BetaRequestMCPServerToolConfigurationTest : TestBase
         List<string> expectedAllowedTools = ["string"];
         bool expectedEnabled = true;
 
+        Assert.NotNull(deserialized.AllowedTools);
         Assert.Equal(expectedAllowedTools.Count, deserialized.AllowedTools.Count);
         for (int i = 0; i < expectedAllowedTools.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaTextBlockParamTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaTextBlockParamTest.cs
@@ -119,6 +119,7 @@ public class BetaTextBlockParamTest : TestBase
         Assert.Equal(expectedText, deserialized.Text);
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
+        Assert.NotNull(deserialized.Citations);
         Assert.Equal(expectedCitations.Count, deserialized.Citations.Count);
         for (int i = 0; i < expectedCitations.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaTextBlockTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaTextBlockTest.cs
@@ -115,6 +115,7 @@ public class BetaTextBlockTest : TestBase
         string expectedText = "text";
         JsonElement expectedType = JsonSerializer.Deserialize<JsonElement>("\"text\"");
 
+        Assert.NotNull(deserialized.Citations);
         Assert.Equal(expectedCitations.Count, deserialized.Citations.Count);
         for (int i = 0; i < expectedCitations.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaTextEditorCodeExecutionStrReplaceResultBlockParamTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaTextEditorCodeExecutionStrReplaceResultBlockParamTest.cs
@@ -85,6 +85,7 @@ public class BetaTextEditorCodeExecutionStrReplaceResultBlockParamTest : TestBas
         long expectedOldStart = 0;
 
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.Lines);
         Assert.Equal(expectedLines.Count, deserialized.Lines.Count);
         for (int i = 0; i < expectedLines.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaTextEditorCodeExecutionStrReplaceResultBlockTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaTextEditorCodeExecutionStrReplaceResultBlockTest.cs
@@ -84,6 +84,7 @@ public class BetaTextEditorCodeExecutionStrReplaceResultBlockTest : TestBase
             "\"text_editor_code_execution_str_replace_result\""
         );
 
+        Assert.NotNull(deserialized.Lines);
         Assert.Equal(expectedLines.Count, deserialized.Lines.Count);
         for (int i = 0; i < expectedLines.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolBash20241022Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolBash20241022Test.cs
@@ -130,6 +130,7 @@ public class BetaToolBash20241022Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -137,6 +138,7 @@ public class BetaToolBash20241022Test : TestBase
         }
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolBash20250124Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolBash20250124Test.cs
@@ -130,6 +130,7 @@ public class BetaToolBash20250124Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -137,6 +138,7 @@ public class BetaToolBash20250124Test : TestBase
         }
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolComputerUse20241022Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolComputerUse20241022Test.cs
@@ -150,6 +150,7 @@ public class BetaToolComputerUse20241022Test : TestBase
         Assert.Equal(expectedDisplayWidthPx, deserialized.DisplayWidthPx);
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -158,6 +159,7 @@ public class BetaToolComputerUse20241022Test : TestBase
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
         Assert.Equal(expectedDisplayNumber, deserialized.DisplayNumber);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolComputerUse20250124Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolComputerUse20250124Test.cs
@@ -150,6 +150,7 @@ public class BetaToolComputerUse20250124Test : TestBase
         Assert.Equal(expectedDisplayWidthPx, deserialized.DisplayWidthPx);
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -158,6 +159,7 @@ public class BetaToolComputerUse20250124Test : TestBase
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
         Assert.Equal(expectedDisplayNumber, deserialized.DisplayNumber);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolComputerUse20251124Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolComputerUse20251124Test.cs
@@ -156,6 +156,7 @@ public class BetaToolComputerUse20251124Test : TestBase
         Assert.Equal(expectedDisplayWidthPx, deserialized.DisplayWidthPx);
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -165,6 +166,7 @@ public class BetaToolComputerUse20251124Test : TestBase
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
         Assert.Equal(expectedDisplayNumber, deserialized.DisplayNumber);
         Assert.Equal(expectedEnableZoom, deserialized.EnableZoom);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolSearchToolBm25_20251119Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolSearchToolBm25_20251119Test.cs
@@ -91,6 +91,7 @@ public class BetaToolSearchToolBm25_20251119Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.Equal(expectedType, deserialized.Type);
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolSearchToolRegex20251119Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolSearchToolRegex20251119Test.cs
@@ -91,6 +91,7 @@ public class BetaToolSearchToolRegex20251119Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.Equal(expectedType, deserialized.Type);
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTest.cs
@@ -188,6 +188,7 @@ public class BetaToolTest : TestBase
 
         Assert.Equal(expectedInputSchema, deserialized.InputSchema);
         Assert.Equal(expectedName, deserialized.Name);
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -196,6 +197,7 @@ public class BetaToolTest : TestBase
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
         Assert.Equal(expectedDescription, deserialized.Description);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {
@@ -584,6 +586,7 @@ public class InputSchemaTest : TestBase
         List<string> expectedRequired = ["location"];
 
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.Properties);
         Assert.Equal(expectedProperties.Count, deserialized.Properties.Count);
         foreach (var item in expectedProperties)
         {
@@ -591,6 +594,7 @@ public class InputSchemaTest : TestBase
 
             Assert.True(JsonElement.DeepEquals(value, deserialized.Properties[item.Key]));
         }
+        Assert.NotNull(deserialized.Required);
         Assert.Equal(expectedRequired.Count, deserialized.Required.Count);
         for (int i = 0; i < expectedRequired.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTextEditor20241022Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTextEditor20241022Test.cs
@@ -138,6 +138,7 @@ public class BetaToolTextEditor20241022Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -145,6 +146,7 @@ public class BetaToolTextEditor20241022Test : TestBase
         }
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTextEditor20250124Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTextEditor20250124Test.cs
@@ -138,6 +138,7 @@ public class BetaToolTextEditor20250124Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -145,6 +146,7 @@ public class BetaToolTextEditor20250124Test : TestBase
         }
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTextEditor20250429Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTextEditor20250429Test.cs
@@ -138,6 +138,7 @@ public class BetaToolTextEditor20250429Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -145,6 +146,7 @@ public class BetaToolTextEditor20250429Test : TestBase
         }
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTextEditor20250728Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaToolTextEditor20250728Test.cs
@@ -144,6 +144,7 @@ public class BetaToolTextEditor20250728Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
@@ -151,6 +152,7 @@ public class BetaToolTextEditor20250728Test : TestBase
         }
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
         Assert.Equal(expectedDeferLoading, deserialized.DeferLoading);
+        Assert.NotNull(deserialized.InputExamples);
         Assert.Equal(expectedInputExamples.Count, deserialized.InputExamples.Count);
         for (int i = 0; i < expectedInputExamples.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaWebFetchTool20250910Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaWebFetchTool20250910Test.cs
@@ -126,16 +126,19 @@ public class BetaWebFetchTool20250910Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
             Assert.Equal(expectedAllowedCallers[i], deserialized.AllowedCallers[i]);
         }
+        Assert.NotNull(deserialized.AllowedDomains);
         Assert.Equal(expectedAllowedDomains.Count, deserialized.AllowedDomains.Count);
         for (int i = 0; i < expectedAllowedDomains.Count; i++)
         {
             Assert.Equal(expectedAllowedDomains[i], deserialized.AllowedDomains[i]);
         }
+        Assert.NotNull(deserialized.BlockedDomains);
         Assert.Equal(expectedBlockedDomains.Count, deserialized.BlockedDomains.Count);
         for (int i = 0; i < expectedBlockedDomains.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaWebSearchTool20250305Test.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaWebSearchTool20250305Test.cs
@@ -150,16 +150,19 @@ public class BetaWebSearchTool20250305Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedCallers);
         Assert.Equal(expectedAllowedCallers.Count, deserialized.AllowedCallers.Count);
         for (int i = 0; i < expectedAllowedCallers.Count; i++)
         {
             Assert.Equal(expectedAllowedCallers[i], deserialized.AllowedCallers[i]);
         }
+        Assert.NotNull(deserialized.AllowedDomains);
         Assert.Equal(expectedAllowedDomains.Count, deserialized.AllowedDomains.Count);
         for (int i = 0; i < expectedAllowedDomains.Count; i++)
         {
             Assert.Equal(expectedAllowedDomains[i], deserialized.AllowedDomains[i]);
         }
+        Assert.NotNull(deserialized.BlockedDomains);
         Assert.Equal(expectedBlockedDomains.Count, deserialized.BlockedDomains.Count);
         for (int i = 0; i < expectedBlockedDomains.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Messages/Batches/BatchCreateParamsTest.cs
+++ b/src/Anthropic.Tests/Models/Messages/Batches/BatchCreateParamsTest.cs
@@ -735,6 +735,7 @@ public class ParamsTest : TestBase
         Assert.Equal(expectedModel, deserialized.Model);
         Assert.Equal(expectedMetadata, deserialized.Metadata);
         Assert.Equal(expectedServiceTier, deserialized.ServiceTier);
+        Assert.NotNull(deserialized.StopSequences);
         Assert.Equal(expectedStopSequences.Count, deserialized.StopSequences.Count);
         for (int i = 0; i < expectedStopSequences.Count; i++)
         {
@@ -745,6 +746,7 @@ public class ParamsTest : TestBase
         Assert.Equal(expectedTemperature, deserialized.Temperature);
         Assert.Equal(expectedThinking, deserialized.Thinking);
         Assert.Equal(expectedToolChoice, deserialized.ToolChoice);
+        Assert.NotNull(deserialized.Tools);
         Assert.Equal(expectedTools.Count, deserialized.Tools.Count);
         for (int i = 0; i < expectedTools.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Messages/MessageTest.cs
+++ b/src/Anthropic.Tests/Models/Messages/MessageTest.cs
@@ -70,7 +70,7 @@ public class MessageTest : TestBase
         ApiEnum<string, Model> expectedModel = Model.ClaudeOpus4_5_20251101;
         JsonElement expectedRole = JsonSerializer.Deserialize<JsonElement>("\"assistant\"");
         ApiEnum<string, StopReason> expectedStopReason = StopReason.EndTurn;
-        string expectedStopSequence = null;
+        string? expectedStopSequence = null;
         JsonElement expectedType = JsonSerializer.Deserialize<JsonElement>("\"message\"");
         Usage expectedUsage = new()
         {
@@ -210,7 +210,7 @@ public class MessageTest : TestBase
         ApiEnum<string, Model> expectedModel = Model.ClaudeOpus4_5_20251101;
         JsonElement expectedRole = JsonSerializer.Deserialize<JsonElement>("\"assistant\"");
         ApiEnum<string, StopReason> expectedStopReason = StopReason.EndTurn;
-        string expectedStopSequence = null;
+        string? expectedStopSequence = null;
         JsonElement expectedType = JsonSerializer.Deserialize<JsonElement>("\"message\"");
         Usage expectedUsage = new()
         {

--- a/src/Anthropic.Tests/Models/Messages/TextBlockParamTest.cs
+++ b/src/Anthropic.Tests/Models/Messages/TextBlockParamTest.cs
@@ -119,6 +119,7 @@ public class TextBlockParamTest : TestBase
         Assert.Equal(expectedText, deserialized.Text);
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
         Assert.Equal(expectedCacheControl, deserialized.CacheControl);
+        Assert.NotNull(deserialized.Citations);
         Assert.Equal(expectedCitations.Count, deserialized.Citations.Count);
         for (int i = 0; i < expectedCitations.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Messages/TextBlockTest.cs
+++ b/src/Anthropic.Tests/Models/Messages/TextBlockTest.cs
@@ -115,6 +115,7 @@ public class TextBlockTest : TestBase
         string expectedText = "text";
         JsonElement expectedType = JsonSerializer.Deserialize<JsonElement>("\"text\"");
 
+        Assert.NotNull(deserialized.Citations);
         Assert.Equal(expectedCitations.Count, deserialized.Citations.Count);
         for (int i = 0; i < expectedCitations.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Messages/ToolTest.cs
+++ b/src/Anthropic.Tests/Models/Messages/ToolTest.cs
@@ -418,6 +418,7 @@ public class InputSchemaTest : TestBase
         List<string> expectedRequired = ["location"];
 
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.Properties);
         Assert.Equal(expectedProperties.Count, deserialized.Properties.Count);
         foreach (var item in expectedProperties)
         {
@@ -425,6 +426,7 @@ public class InputSchemaTest : TestBase
 
             Assert.True(JsonElement.DeepEquals(value, deserialized.Properties[item.Key]));
         }
+        Assert.NotNull(deserialized.Required);
         Assert.Equal(expectedRequired.Count, deserialized.Required.Count);
         for (int i = 0; i < expectedRequired.Count; i++)
         {

--- a/src/Anthropic.Tests/Models/Messages/WebSearchTool20250305Test.cs
+++ b/src/Anthropic.Tests/Models/Messages/WebSearchTool20250305Test.cs
@@ -121,11 +121,13 @@ public class WebSearchTool20250305Test : TestBase
 
         Assert.True(JsonElement.DeepEquals(expectedName, deserialized.Name));
         Assert.True(JsonElement.DeepEquals(expectedType, deserialized.Type));
+        Assert.NotNull(deserialized.AllowedDomains);
         Assert.Equal(expectedAllowedDomains.Count, deserialized.AllowedDomains.Count);
         for (int i = 0; i < expectedAllowedDomains.Count; i++)
         {
             Assert.Equal(expectedAllowedDomains[i], deserialized.AllowedDomains[i]);
         }
+        Assert.NotNull(deserialized.BlockedDomains);
         Assert.Equal(expectedBlockedDomains.Count, deserialized.BlockedDomains.Count);
         for (int i = 0; i < expectedBlockedDomains.Count; i++)
         {


### PR DESCRIPTION
There are currently 62 build warnings. They're driving me a bit nuts :) Fixing them all, and turning on warnings as errors (I've added a Directory.Build.props... more centralized settings should subsequently be moved from the csproj into this).