### PR TITLE
MicrosoftExtensions: Normalize nullable union tool types

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientBetaExtensionsTests.cs
+++ b/src/Anthropic.Tests/AnthropicClientBetaExtensionsTests.cs
@@ -2304,4 +2304,174 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
         Assert.Equal("application/pdf", files[1].MediaType);
         Assert.Equal(2000, files[1].SizeInBytes);
     }
+
+    [Fact]
+    public async Task GetResponseAsync_WithNullableUnionType_TransformsToSimpleType()
+    {
+        // The C# MCP SDK generates schemas with "type": ["integer", "null"], "default": null
+        // for optional nullable parameters. This test verifies the transformation removes
+        // the null from the union type and the default: null for non-required properties.
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Call tool with optional param"
+                    }]
+                }],
+                "tools": [{
+                    "name": "tool_with_optional",
+                    "description": "A tool with an optional nullable parameter",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {
+                            "required_param": {
+                                "type": "string"
+                            },
+                            "optional_number": {
+                                "type": "integer",
+                                "description": "{default: null}"
+                            }
+                        },
+                        "required": ["required_param"],
+                        "additionalProperties": false
+                    }
+                }]
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_nullable_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "Tool ready"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 30,
+                    "output_tokens": 5
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        // Create a function with an optional nullable parameter - the schema will have
+        // "type": ["integer", "null"], "default": null which should be transformed
+        var functionWithOptional = AIFunctionFactory.Create(
+            (string required_param, int? optional_number = null) => "result",
+            new AIFunctionFactoryOptions
+            {
+                Name = "tool_with_optional",
+                Description = "A tool with an optional nullable parameter",
+            }
+        );
+
+        ChatOptions options = new() { Tools = [functionWithOptional] };
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            "Call tool with optional param",
+            options,
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_WithRequiredNullableUnionType_PreservesUnionType()
+    {
+        // When a property IS in the required array but has a nullable union type,
+        // we should NOT transform it - let the API fail with a meaningful error
+        // rather than silently misrepresenting the schema.
+        // Using BetaTool.AsAITool() bypasses the schema transformation, so this test
+        // verifies the raw tool passes through unchanged.
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Call tool with required nullable"
+                    }]
+                }],
+                "tools": [{
+                    "name": "tool_with_required_nullable",
+                    "description": "A tool with a required nullable parameter",
+                    "input_schema": {
+                        "nullable_number": {
+                            "type": ["integer", "null"],
+                            "description": "A required but nullable number"
+                        },
+                        "type": "object",
+                        "required": ["nullable_number"]
+                    }
+                }]
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_required_nullable_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "Tool ready"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 30,
+                    "output_tokens": 5
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        // Create a BetaTool with a required nullable parameter using raw schema
+        // This simulates a schema that came from elsewhere (not C# MCP SDK pattern)
+#pragma warning disable CA1861 // Prefer 'static readonly' fields over constant array arguments - test method only runs once
+        BetaToolUnion rawTool = new BetaTool
+        {
+            Name = "tool_with_required_nullable",
+            Description = "A tool with a required nullable parameter",
+            InputSchema = new InputSchema(
+                new Dictionary<string, JsonElement>
+                {
+                    ["nullable_number"] = JsonSerializer.SerializeToElement(
+                        new
+                        {
+                            type = new[] { "integer", "null" },
+                            description = "A required but nullable number",
+                        }
+                    ),
+                }
+            )
+            {
+                Required = ["nullable_number"],
+            },
+        };
+#pragma warning restore CA1861
+
+        ChatOptions options = new() { Tools = [rawTool.AsAITool()] };
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            "Call tool with required nullable",
+            options,
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
 }

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -284,6 +284,87 @@ public static class AnthropicClientExtensions
                             : constraintInfo;
                     }
 
+                    // Handle nullable union types (e.g., "type": ["integer", "null"]) for
+                    // non-required properties. The C# MCP SDK generates these for optional
+                    // parameters, but structured outputs doesn't support union types.
+                    // Only transform non-required properties; required + nullable is an
+                    // incompatible schema that should fail at the API level.
+                    if (
+                        schemaObj.TryGetPropertyValue("properties", out JsonNode? propsNode)
+                        && propsNode is JsonObject propsObj
+                    )
+                    {
+                        HashSet<string> requiredProps = [];
+                        if (
+                            schemaObj.TryGetPropertyValue("required", out JsonNode? reqNode)
+                            && reqNode is JsonArray reqArray
+                        )
+                        {
+                            foreach (JsonNode? req in reqArray)
+                            {
+                                if (req?.GetValue<string>() is string reqName)
+                                {
+                                    requiredProps.Add(reqName);
+                                }
+                            }
+                        }
+
+                        foreach (var prop in propsObj)
+                        {
+                            if (requiredProps.Contains(prop.Key))
+                            {
+                                continue;
+                            }
+
+                            if (prop.Value is not JsonObject propSchema)
+                            {
+                                continue;
+                            }
+
+                            if (
+                                !propSchema.TryGetPropertyValue("type", out JsonNode? propTypeNode)
+                                || propTypeNode is not JsonArray typeArray
+                            )
+                            {
+                                continue;
+                            }
+
+                            int nullIndex = -1;
+                            for (int i = 0; i < typeArray.Count; i++)
+                            {
+                                if (typeArray[i]?.GetValue<string>() == "null")
+                                {
+                                    nullIndex = i;
+                                    break;
+                                }
+                            }
+
+                            if (nullIndex < 0)
+                            {
+                                continue;
+                            }
+
+                            typeArray.RemoveAt(nullIndex);
+
+                            if (typeArray.Count == 1)
+                            {
+                                propSchema["type"] = typeArray[0]?.DeepClone();
+                            }
+
+                            if (
+                                propSchema.TryGetPropertyValue(
+                                    "default",
+                                    out JsonNode? defaultNode
+                                )
+                                && defaultNode is JsonValue defaultValue
+                                && defaultValue.GetValueKind() == JsonValueKind.Null
+                            )
+                            {
+                                propSchema.Remove("default");
+                            }
+                        }
+                    }
+
                     return schemaNode;
                 },
             }


### PR DESCRIPTION
See: https://github.com/modelcontextprotocol/csharp-sdk/issues/1091

Tools with `["integer", "null"]` discriminated union style types to provide additional information on default when non provided for non-required properties would cause the following error:

`tools.0.custom.input_schema: JSON schema is invalid. It must match JSON Schema draft 2020-12 (https://json-schema.org/draft/2020-12). Learn more about tool use at https://docs.claude.com/en/docs/tool-use.`