### PR TITLE
fix: remove using statement from FileService.Download to prevent Obje…

### DIFF
--- a/src/Anthropic/Services/Beta/FileService.cs
+++ b/src/Anthropic/Services/Beta/FileService.cs
@@ -112,7 +112,9 @@ public sealed class FileService : IFileService
             Method = HttpMethod.Get,
             Params = parameters,
         };
-        using var response = await this
+        // Note: We intentionally do not dispose the response here.
+        // The caller is responsible for disposing the returned HttpResponse.
+        var response = await this
             ._client.Execute(request, cancellationToken)
             .ConfigureAwait(false);
         return response;

--- a/src/Anthropic/Services/Beta/IFileService.cs
+++ b/src/Anthropic/Services/Beta/IFileService.cs
@@ -46,12 +46,23 @@ public interface IFileService
     /// <summary>
     /// Download File
     /// </summary>
+    /// <remarks>
+    /// The caller is responsible for disposing the returned <see cref="HttpResponse"/>.
+    /// Unlike other methods in this service, this method returns the raw response
+    /// for streaming access to file content.
+    /// </remarks>
+    /// <param name="parameters">The download parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The HTTP response containing the file content. Must be disposed by the caller.</returns>
     Task<HttpResponse> Download(
         FileDownloadParams parameters,
         CancellationToken cancellationToken = default
     );
 
     /// <inheritdoc cref="Download(FileDownloadParams, CancellationToken)"/>
+    /// <param name="fileID">The file ID to download.</param>
+    /// <param name="parameters">Optional download parameters.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     Task<HttpResponse> Download(
         string fileID,
         FileDownloadParams? parameters = null,


### PR DESCRIPTION
Fixes #85

## Summary

`FileService.Download` uses `using var response` but returns the response, disposing it before the caller can use it.

**Fix:** Remove `using`, add XML docs clarifying caller disposal responsibility.

## Contribution Checklist

- [x] Builds clean
- [x] Follows existing SDK patterns
- [x] No breaking changes
- [x] Tests pass

