### PR TITLE
fix: make ToolUseBlock.Caller nullable for non-MCP tool calls

### DIFF
--- a/src/Anthropic.Tests/Models/Messages/ToolUseBlockTest.cs
+++ b/src/Anthropic.Tests/Models/Messages/ToolUseBlockTest.cs
@@ -144,6 +144,78 @@ public class ToolUseBlockTest : TestBase
 
         Assert.Equal(model, copied);
     }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesUnsetAreNotSet_Works()
+    {
+        var model = new ToolUseBlock
+        {
+            ID = "id",
+            Input = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Name = "x",
+        };
+
+        Assert.Null(model.Caller);
+        Assert.False(model.RawData.ContainsKey("caller"));
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesUnsetValidation_Works()
+    {
+        var model = new ToolUseBlock
+        {
+            ID = "id",
+            Input = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Name = "x",
+        };
+
+        model.Validate();
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesSetToNullAreNotSet_Works()
+    {
+        var model = new ToolUseBlock
+        {
+            ID = "id",
+            Input = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Name = "x",
+
+            // Null should be interpreted as omitted for these properties
+            Caller = null,
+        };
+
+        Assert.Null(model.Caller);
+        Assert.False(model.RawData.ContainsKey("caller"));
+    }
+
+    [Fact]
+    public void OptionalNonNullablePropertiesSetToNullValidation_Works()
+    {
+        var model = new ToolUseBlock
+        {
+            ID = "id",
+            Input = new Dictionary<string, JsonElement>()
+            {
+                { "foo", JsonSerializer.SerializeToElement("bar") },
+            },
+            Name = "x",
+
+            // Null should be interpreted as omitted for these properties
+            Caller = null,
+        };
+
+        model.Validate();
+    }
 }
 
 public class ToolUseBlockCallerTest : TestBase

--- a/src/Anthropic/Models/Messages/ToolUseBlock.cs
+++ b/src/Anthropic/Models/Messages/ToolUseBlock.cs
@@ -24,15 +24,24 @@ public sealed record class ToolUseBlock : JsonModel
 
     /// <summary>
     /// Tool invocation directly from the model.
+    /// When absent, the caller is implicitly "direct" (the model itself).
     /// </summary>
-    public required ToolUseBlockCaller Caller
+    public ToolUseBlockCaller? Caller
     {
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNotNullClass<ToolUseBlockCaller>("caller");
+            return this._rawData.GetNullableClass<ToolUseBlockCaller>("caller");
         }
-        init { this._rawData.Set("caller", value); }
+        init
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            this._rawData.Set("caller", value);
+        }
     }
 
     public required IReadOnlyDictionary<string, JsonElement> Input
@@ -75,7 +84,7 @@ public sealed record class ToolUseBlock : JsonModel
     public override void Validate()
     {
         _ = this.ID;
-        this.Caller.Validate();
+        this.Caller?.Validate();
         _ = this.Input;
         _ = this.Name;
         if (!JsonElement.DeepEquals(this.Type, JsonSerializer.SerializeToElement("tool_use")))


### PR DESCRIPTION
## Summary

- `ToolUseBlock.Caller` was marked `required` with `GetNotNullClass`, but the API does not include a `caller` field in `tool_use` content blocks for standard (non-MCP) tool calls. This caused `AnthropicInvalidDataException` ("'caller' cannot be absent") during streaming deserialization.
- Changed `Caller` from `required ToolUseBlockCaller` to `ToolUseBlockCaller?`, using `GetNullableClass` and a null-guarding init setter consistent with other optional properties in the codebase.
- Added tests covering unset and explicitly-null `Caller` for both property access and validation.

## Reproduction

```
Anthropic.Exceptions.AnthropicInvalidDataException: 'caller' cannot be absent
   at Anthropic.Core.JsonDictionary.GetNotNullClass[T](String key)
   at Anthropic.Models.Messages.ToolUseBlock.Caller.get()
   at Anthropic.Models.Messages.ToolUseBlock.Validate()
   at Anthropic.Models.Messages.RawContentBlockStartEvent.ContentBlock.get()
```

Any Claude model returning a standard `tool_use` block (non-MCP) triggers this during streaming via `AsIChatClient()`.

## Test plan

- [x] `OptionalNonNullablePropertiesUnsetAreNotSet_Works` — `Caller` is null and absent from `RawData` when not set
- [x] `OptionalNonNullablePropertiesUnsetValidation_Works` — `Validate()` passes without `Caller`
- [x] `OptionalNonNullablePropertiesSetToNullAreNotSet_Works` — explicit `null` does not insert into `RawData`
- [x] `OptionalNonNullablePropertiesSetToNullValidation_Works` — `Validate()` passes with explicit `null`
- [x] Existing `ToolUseBlockTest` and `ToolUseBlockCallerTest` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)