### PR TITLE
fix: add string case to FunctionResultContent.Result switch to prevent double-serialization

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -1211,7 +1211,7 @@ public abstract class AnthropicClientExtensionsTestsBase
                         "content": [{
                             "type": "tool_result",
                             "tool_use_id": "toolu_12345",
-                            "content": "\"Sunny, 22 degrees celsius\"",
+                            "content": "Sunny, 22 degrees celsius",
                             "is_error": false
                         }]
                     }

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -589,6 +589,8 @@ public static class AnthropicClientExtensions
                             {
                                 ToolResultBlockParamContent trbpc => trbpc,
 
+                                string s => new(s),
+
                                 AIContent aiContent => new(ToResultBlocks([aiContent])),
 
                                 IEnumerable<AIContent> aiContents => new(

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -688,6 +688,8 @@ public static class AnthropicBetaClientExtensions
                             {
                                 BetaToolResultBlockParamContent btrbpc => btrbpc,
 
+                                string s => new(s),
+
                                 AIContent aiContent => new(ToResultBlocks([aiContent])),
 
                                 IEnumerable<AIContent> aiContents => new(


### PR DESCRIPTION
Fixes #163

## Problem

The `FunctionResultContent.Result` switch in both `AnthropicClientExtensions.cs` and `AnthropicBetaClientExtensions.cs` is missing a `string` case. When `Result` is a plain string (the most common case - tool results from `Microsoft.Extensions.AI` are typically strings), it falls through to the `_` default which calls `JsonSerializer.Serialize(result, typeof(object))`.

This **double-encodes** the string:

| Input (`FunctionResultContent.Result`) | Wire output (current) | Wire output (expected) |
|---|---|---|
| `hello\tworld` | `"hello\\tworld"` | `hello\tworld` |
| `Sunny, 22°C` | `"Sunny, 22°C"` | `Sunny, 22°C` |

The extra JSON serialization wraps the value in quotes and escapes special characters, which:

1. **Breaks prompt caching** - when `RawRepresentation` is set (e.g., at a cache breakpoint), the string goes to the wire cleanly. When `RawRepresentation` is not set, the SDK's `_` fallback double-encodes it. The wire bytes differ between requests, breaking the prefix hash and stalling cache reads. In our testing with mitmproxy across 16 Opus requests, double-escaped tool results caused cache stalls 4/4 times while identical content advanced 9/9 times.

2. **Degrades model comprehension** - tool results often contain file contents, code, or multi-line text where `\t` becoming `\\t` and added quote wrapping changes the meaning.

## Fix

Add `string s => new(s)` before the `AIContent` cases in both:
- `AnthropicBetaClientExtensions.cs` (line 689)
- `AnthropicClientExtensions.cs` (line 590)

This matches the **Python SDK's behavior** where tool results are typed as [`Union[str, Iterable[Content]]`](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/types/tool_result_block_param.py#L27) - strings are passed directly to the API without serialization.

Updated the existing `GetResponseAsync_WithFunctionResults` test assertion that was validating the incorrect double-encoded output.

## Testing

All 4829 existing tests pass, including the updated `GetResponseAsync_WithFunctionResults` test which now asserts the correct (non-double-encoded) wire format.