### PR TITLE
fix(client): merge response format into preconfigured output config

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientBetaExtensionsTests.cs
+++ b/src/Anthropic.Tests/AnthropicClientBetaExtensionsTests.cs
@@ -912,6 +912,91 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
     }
 
     [Fact]
+    public async Task GetResponseAsync_WithResponseFormatAndPreconfiguredOutputConfig_MergesFormat()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 2048,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Return JSON"
+                    }]
+                }],
+                "output_config": {
+                    "effort": "medium",
+                    "format": {
+                        "type": "json_schema",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "answer": { "type": "string" }
+                            },
+                            "required": ["answer"],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_factory_output_config_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "{\"answer\":\"Response\"}"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 20,
+                    "output_tokens": 5
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        ChatOptions options = new()
+        {
+            RawRepresentationFactory = _ => new MessageCreateParams()
+            {
+                MaxTokens = 2048,
+                Model = "claude-haiku-4-5",
+                Messages = [],
+                OutputConfig = new BetaOutputConfig() { Effort = Effort.Medium },
+            },
+            ResponseFormat = ChatResponseFormat.ForJsonSchema(
+                JsonElement.Parse(
+                    """
+                    {
+                        "type": "object",
+                        "properties": {
+                            "answer": { "type": "string" }
+                        },
+                        "required": ["answer"]
+                    }
+                    """
+                ),
+                "answer_response"
+            ),
+        };
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            "Return JSON",
+            options,
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
+
+    [Fact]
     public async Task GetResponseAsync_WithNonEmptyMessageParams_EmptyMessages()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic.Tests/AnthropicClientExtensionsTests.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTests.cs
@@ -339,6 +339,91 @@ public class AnthropicClientExtensionsTests : AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetResponseAsync_WithResponseFormatAndPreconfiguredOutputConfig_MergesFormat()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 2048,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Return JSON"
+                    }]
+                }],
+                "output_config": {
+                    "effort": "medium",
+                    "format": {
+                        "type": "json_schema",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "answer": { "type": "string" }
+                            },
+                            "required": ["answer"],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_factory_output_config_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "{\"answer\":\"Response\"}"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 20,
+                    "output_tokens": 5
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        ChatOptions options = new()
+        {
+            RawRepresentationFactory = _ => new MessageCreateParams()
+            {
+                MaxTokens = 2048,
+                Model = "claude-haiku-4-5",
+                Messages = [],
+                OutputConfig = new OutputConfig() { Effort = Effort.Medium },
+            },
+            ResponseFormat = ChatResponseFormat.ForJsonSchema(
+                JsonElement.Parse(
+                    """
+                    {
+                        "type": "object",
+                        "properties": {
+                            "answer": { "type": "string" }
+                        },
+                        "required": ["answer"]
+                    }
+                    """
+                ),
+                "answer_response"
+            ),
+        };
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            "Return JSON",
+            options,
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
+
+    [Fact]
     public async Task GetResponseAsync_WithNonEmptyMessageParams_EmptyMessages()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -1202,7 +1202,9 @@ public static class AnthropicClientExtensions
                             {
                                 createParams = createParams with
                                 {
-                                    OutputConfig = (createParams.OutputConfig ?? new OutputConfig()) with
+                                    OutputConfig = (
+                                        createParams.OutputConfig ?? new OutputConfig()
+                                    ) with
                                     {
                                         Format = new JsonOutputFormat()
                                         {

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -1183,7 +1183,7 @@ public static class AnthropicClientExtensions
                 }
 
                 if (
-                    createParams.OutputConfig is null
+                    createParams.OutputConfig?.Format is null
                     && options.ResponseFormat is { } responseFormat
                 )
                 {
@@ -1202,7 +1202,7 @@ public static class AnthropicClientExtensions
                             {
                                 createParams = createParams with
                                 {
-                                    OutputConfig = new OutputConfig()
+                                    OutputConfig = (createParams.OutputConfig ?? new OutputConfig()) with
                                     {
                                         Format = new JsonOutputFormat()
                                         {

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -954,7 +954,7 @@ public static class AnthropicBetaClientExtensions
                 }
 
                 if (
-                    createParams.OutputFormat is null
+                    createParams.OutputConfig?.Format is null
                     && options.ResponseFormat is { } responseFormat
                 )
                 {
@@ -973,21 +973,22 @@ public static class AnthropicBetaClientExtensions
                             {
                                 createParams = createParams with
                                 {
-                                    OutputConfig = new BetaOutputConfig()
-                                    {
-                                        Format = new BetaJsonOutputFormat()
+                                    OutputConfig =
+                                        (createParams.OutputConfig ?? new BetaOutputConfig()) with
                                         {
-                                            Schema = new Dictionary<string, JsonElement>
+                                            Format = new BetaJsonOutputFormat()
                                             {
-                                                ["type"] = JsonElement.Parse("\"object\""),
-                                                ["properties"] = properties,
-                                                ["required"] = required,
-                                                ["additionalProperties"] = JsonElement.Parse(
-                                                    "false"
-                                                ),
+                                                Schema = new Dictionary<string, JsonElement>
+                                                {
+                                                    ["type"] = JsonElement.Parse("\"object\""),
+                                                    ["properties"] = properties,
+                                                    ["required"] = required,
+                                                    ["additionalProperties"] = JsonElement.Parse(
+                                                        "false"
+                                                    ),
+                                                },
                                             },
                                         },
-                                    },
                                 };
                             }
                             break;

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -973,22 +973,23 @@ public static class AnthropicBetaClientExtensions
                             {
                                 createParams = createParams with
                                 {
-                                    OutputConfig =
-                                        (createParams.OutputConfig ?? new BetaOutputConfig()) with
+                                    OutputConfig = (
+                                        createParams.OutputConfig ?? new BetaOutputConfig()
+                                    ) with
+                                    {
+                                        Format = new BetaJsonOutputFormat()
                                         {
-                                            Format = new BetaJsonOutputFormat()
+                                            Schema = new Dictionary<string, JsonElement>
                                             {
-                                                Schema = new Dictionary<string, JsonElement>
-                                                {
-                                                    ["type"] = JsonElement.Parse("\"object\""),
-                                                    ["properties"] = properties,
-                                                    ["required"] = required,
-                                                    ["additionalProperties"] = JsonElement.Parse(
-                                                        "false"
-                                                    ),
-                                                },
+                                                ["type"] = JsonElement.Parse("\"object\""),
+                                                ["properties"] = properties,
+                                                ["required"] = required,
+                                                ["additionalProperties"] = JsonElement.Parse(
+                                                    "false"
+                                                ),
                                             },
                                         },
+                                    },
                                 };
                             }
                             break;


### PR DESCRIPTION
## Summary
- merge ChatOptions.ResponseFormat into an existing OutputConfig instead of skipping it when RawRepresentationFactory preconfigures output settings
- keep beta behavior aligned by only checking the canonical OutputConfig.Format
- add regression coverage for standard and beta chat adapters

Fixes #165.