### PR TITLE
fix(client): Treat empty json string in meai tool call as having 'no' arguments.

### DIFF
--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -1996,13 +1996,15 @@ public static class AnthropicClientExtensions
                     functionData.CallId,
                     functionData.Name,
                     json =>
-                        (Dictionary<string, object?>?)
-                            JsonSerializer.Deserialize(
-                                json,
-                                AIJsonUtilities.DefaultOptions.GetTypeInfo(
-                                    typeof(Dictionary<string, object?>)
+                        json.Length == 0
+                            ? null
+                            : (Dictionary<string, object?>?)
+                                JsonSerializer.Deserialize(
+                                    json,
+                                    AIJsonUtilities.DefaultOptions.GetTypeInfo(
+                                        typeof(Dictionary<string, object?>)
+                                    )
                                 )
-                            )
                 );
             }
 

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1921,13 +1921,15 @@ public static class AnthropicBetaClientExtensions
                     functionData.CallId,
                     functionData.Name,
                     json =>
-                        (Dictionary<string, object?>?)
-                            JsonSerializer.Deserialize(
-                                json,
-                                AIJsonUtilities.DefaultOptions.GetTypeInfo(
-                                    typeof(Dictionary<string, object?>)
+                        json.Length == 0
+                            ? null
+                            : (Dictionary<string, object?>?)
+                                JsonSerializer.Deserialize(
+                                    json,
+                                    AIJsonUtilities.DefaultOptions.GetTypeInfo(
+                                        typeof(Dictionary<string, object?>)
+                                    )
                                 )
-                            )
                 );
             }
 


### PR DESCRIPTION
If a non-server tool has no arguments, it's currently still run through the json deserializer, which raises a JsonException.  

This doesn't stop the chat client from working, CreateFromParsedArguments just seems to log the exception in the created FunctionCallContent, but it does mean a noisy exception, and the created FunctionCallContent doesn't reflect the true state of play.

This PR handles an empty string as meaning there was no arguments given, which I think is how we should handle this.