### PR TITLE
Make ServerToolUsage/BetaServerToolUsage web request counts nullable

### DIFF
--- a/src/Anthropic.Tests/Models/Beta/Messages/BetaServerToolUsageTest.cs
+++ b/src/Anthropic.Tests/Models/Beta/Messages/BetaServerToolUsageTest.cs
@@ -11,8 +11,8 @@ public class BetaServerToolUsageTest : TestBase
     {
         var model = new BetaServerToolUsage { WebFetchRequests = 2, WebSearchRequests = 0 };
 
-        long expectedWebFetchRequests = 2;
-        long expectedWebSearchRequests = 0;
+        long? expectedWebFetchRequests = 2;
+        long? expectedWebSearchRequests = 0;
 
         Assert.Equal(expectedWebFetchRequests, model.WebFetchRequests);
         Assert.Equal(expectedWebSearchRequests, model.WebSearchRequests);
@@ -44,8 +44,8 @@ public class BetaServerToolUsageTest : TestBase
         );
         Assert.NotNull(deserialized);
 
-        long expectedWebFetchRequests = 2;
-        long expectedWebSearchRequests = 0;
+        long? expectedWebFetchRequests = 2;
+        long? expectedWebSearchRequests = 0;
 
         Assert.Equal(expectedWebFetchRequests, deserialized.WebFetchRequests);
         Assert.Equal(expectedWebSearchRequests, deserialized.WebSearchRequests);
@@ -56,6 +56,20 @@ public class BetaServerToolUsageTest : TestBase
     {
         var model = new BetaServerToolUsage { WebFetchRequests = 2, WebSearchRequests = 0 };
 
+        model.Validate();
+    }
+
+    [Fact]
+    public void MissingFields_AreNullableAndValidationDoesNotThrow()
+    {
+        var model = JsonSerializer.Deserialize<BetaServerToolUsage>(
+            "{}",
+            ModelBase.SerializerOptions
+        );
+        Assert.NotNull(model);
+
+        Assert.Null(model.WebFetchRequests);
+        Assert.Null(model.WebSearchRequests);
         model.Validate();
     }
 

--- a/src/Anthropic.Tests/Models/Messages/ServerToolUsageTest.cs
+++ b/src/Anthropic.Tests/Models/Messages/ServerToolUsageTest.cs
@@ -11,8 +11,8 @@ public class ServerToolUsageTest : TestBase
     {
         var model = new ServerToolUsage { WebFetchRequests = 2, WebSearchRequests = 0 };
 
-        long expectedWebFetchRequests = 2;
-        long expectedWebSearchRequests = 0;
+        long? expectedWebFetchRequests = 2;
+        long? expectedWebSearchRequests = 0;
 
         Assert.Equal(expectedWebFetchRequests, model.WebFetchRequests);
         Assert.Equal(expectedWebSearchRequests, model.WebSearchRequests);
@@ -44,8 +44,8 @@ public class ServerToolUsageTest : TestBase
         );
         Assert.NotNull(deserialized);
 
-        long expectedWebFetchRequests = 2;
-        long expectedWebSearchRequests = 0;
+        long? expectedWebFetchRequests = 2;
+        long? expectedWebSearchRequests = 0;
 
         Assert.Equal(expectedWebFetchRequests, deserialized.WebFetchRequests);
         Assert.Equal(expectedWebSearchRequests, deserialized.WebSearchRequests);
@@ -56,6 +56,20 @@ public class ServerToolUsageTest : TestBase
     {
         var model = new ServerToolUsage { WebFetchRequests = 2, WebSearchRequests = 0 };
 
+        model.Validate();
+    }
+
+    [Fact]
+    public void MissingFields_AreNullableAndValidationDoesNotThrow()
+    {
+        var model = JsonSerializer.Deserialize<ServerToolUsage>(
+            "{}",
+            ModelBase.SerializerOptions
+        );
+        Assert.NotNull(model);
+
+        Assert.Null(model.WebFetchRequests);
+        Assert.Null(model.WebSearchRequests);
         model.Validate();
     }
 

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -1507,13 +1507,13 @@ public static class AnthropicClientExtensions
             if (serverToolUsage?.WebFetchRequests is > 0)
             {
                 (usageDetails.AdditionalCounts ??= [])[nameof(ServerToolUsage.WebFetchRequests)] =
-                    serverToolUsage.WebFetchRequests;
+                    serverToolUsage.WebFetchRequests.Value;
             }
 
             if (serverToolUsage?.WebSearchRequests is > 0)
             {
                 (usageDetails.AdditionalCounts ??= [])[nameof(ServerToolUsage.WebSearchRequests)] =
-                    serverToolUsage.WebSearchRequests;
+                    serverToolUsage.WebSearchRequests.Value;
             }
 
             return usageDetails;

--- a/src/Anthropic/Models/Beta/Messages/BetaServerToolUsage.cs
+++ b/src/Anthropic/Models/Beta/Messages/BetaServerToolUsage.cs
@@ -13,12 +13,12 @@ public sealed record class BetaServerToolUsage : JsonModel
     /// <summary>
     /// The number of web fetch tool requests.
     /// </summary>
-    public required long WebFetchRequests
+    public long? WebFetchRequests
     {
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNotNullStruct<long>("web_fetch_requests");
+            return this._rawData.GetNullableStruct<long>("web_fetch_requests");
         }
         init { this._rawData.Set("web_fetch_requests", value); }
     }
@@ -26,12 +26,12 @@ public sealed record class BetaServerToolUsage : JsonModel
     /// <summary>
     /// The number of web search tool requests.
     /// </summary>
-    public required long WebSearchRequests
+    public long? WebSearchRequests
     {
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNotNullStruct<long>("web_search_requests");
+            return this._rawData.GetNullableStruct<long>("web_search_requests");
         }
         init { this._rawData.Set("web_search_requests", value); }
     }
@@ -39,8 +39,15 @@ public sealed record class BetaServerToolUsage : JsonModel
     /// <inheritdoc/>
     public override void Validate()
     {
-        _ = this.WebFetchRequests;
-        _ = this.WebSearchRequests;
+        var rawData = this.RawData;
+        if (rawData.ContainsKey("web_fetch_requests"))
+        {
+            _ = this.WebFetchRequests;
+        }
+        if (rawData.ContainsKey("web_search_requests"))
+        {
+            _ = this.WebSearchRequests;
+        }
     }
 
     public BetaServerToolUsage() { }

--- a/src/Anthropic/Models/Messages/ServerToolUsage.cs
+++ b/src/Anthropic/Models/Messages/ServerToolUsage.cs
@@ -13,12 +13,12 @@ public sealed record class ServerToolUsage : JsonModel
     /// <summary>
     /// The number of web fetch tool requests.
     /// </summary>
-    public required long WebFetchRequests
+    public long? WebFetchRequests
     {
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNotNullStruct<long>("web_fetch_requests");
+            return this._rawData.GetNullableStruct<long>("web_fetch_requests");
         }
         init { this._rawData.Set("web_fetch_requests", value); }
     }
@@ -26,12 +26,12 @@ public sealed record class ServerToolUsage : JsonModel
     /// <summary>
     /// The number of web search tool requests.
     /// </summary>
-    public required long WebSearchRequests
+    public long? WebSearchRequests
     {
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNotNullStruct<long>("web_search_requests");
+            return this._rawData.GetNullableStruct<long>("web_search_requests");
         }
         init { this._rawData.Set("web_search_requests", value); }
     }
@@ -39,8 +39,15 @@ public sealed record class ServerToolUsage : JsonModel
     /// <inheritdoc/>
     public override void Validate()
     {
-        _ = this.WebFetchRequests;
-        _ = this.WebSearchRequests;
+        var rawData = this.RawData;
+        if (rawData.ContainsKey("web_fetch_requests"))
+        {
+            _ = this.WebFetchRequests;
+        }
+        if (rawData.ContainsKey("web_search_requests"))
+        {
+            _ = this.WebSearchRequests;
+        }
     }
 
     public ServerToolUsage() { }

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1357,14 +1357,14 @@ public static class AnthropicBetaClientExtensions
             {
                 (usageDetails.AdditionalCounts ??= [])[
                     nameof(BetaServerToolUsage.WebFetchRequests)
-                ] = serverToolUsage.WebFetchRequests;
+                ] = serverToolUsage.WebFetchRequests.Value;
             }
 
             if (serverToolUsage?.WebSearchRequests is > 0)
             {
                 (usageDetails.AdditionalCounts ??= [])[
                     nameof(BetaServerToolUsage.WebSearchRequests)
-                ] = serverToolUsage.WebSearchRequests;
+                ] = serverToolUsage.WebSearchRequests.Value;
             }
 
             return usageDetails;


### PR DESCRIPTION
## Summary
- make WebFetchRequests and WebSearchRequests nullable (long?) in both ServerToolUsage and BetaServerToolUsage
- switch getters to GetNullableStruct(...)
- update Validate() to validate keys only when present
- update usage-mapping callsites to handle nullable values safely
- add missing-field tests for both beta and non-beta models

## Why
web_fetch_requests and web_search_requests can be absent in real payloads. Treating them as required caused runtime exceptions.

Fixes #174