### PR TITLE
Handle missing streaming thinking signatures

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,4 @@
 configured_endpoints: 76
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-e0696f59ae07dc1a9c5a8fc87a4eb05eb35afabaac0b5ff0ea38810fa9dd4a74.yml
+openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-887672e4d20da26b724d31b0da770624a3b296558994dde969b5784f48777e6f.yml
 openapi_spec_hash: 69278ebbb0d1aa0b322bbbd5128bcec5
-config_hash: b0dbd234c2752507397c139a416f6cba
+config_hash: b28d789e5ee5c2419cd06c9d0497642f

--- a/scripts/mock
+++ b/scripts/mock
@@ -22,9 +22,9 @@ echo "==> Starting mock server with URL ${URL}"
 # Run prism mock on the given spec
 if [ "$1" == "--daemon" ]; then
   # Pre-install the package so the download doesn't eat into the startup timeout
-  npm exec --package=@stdy/cli@0.20.2 -- steady --version
+  npm exec --package=@stdy/cli@0.22.1 -- steady --version
 
-  npm exec --package=@stdy/cli@0.20.2 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=comma --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL" &> .stdy.log &
+  npm exec --package=@stdy/cli@0.22.1 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=comma --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL" &> .stdy.log &
 
   # Wait for server to come online via health endpoint (max 30s)
   echo -n "Waiting for server"
@@ -53,5 +53,5 @@ if [ "$1" == "--daemon" ]; then
 
   echo
 else
-  npm exec --package=@stdy/cli@0.20.2 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=comma --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL"
+  npm exec --package=@stdy/cli@0.22.1 -- steady --host 127.0.0.1 -p 4010 --validator-query-array-format=comma --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets "$URL"
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -47,7 +47,7 @@ elif ! prism_is_running ; then
   echo -e "To run the server, pass in the path or url of your OpenAPI"
   echo -e "spec to the prism command:"
   echo
-  echo -e "  \$ ${YELLOW}npm exec --package=@stdy/cli@0.20.2 -- steady path/to/your.openapi.yml --host 127.0.0.1 -p 4010 --validator-query-array-format=comma --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets${NC}"
+  echo -e "  \$ ${YELLOW}npm exec --package=@stdy/cli@0.22.1 -- steady path/to/your.openapi.yml --host 127.0.0.1 -p 4010 --validator-query-array-format=comma --validator-form-array-format=brackets --validator-query-object-format=brackets --validator-form-object-format=brackets${NC}"
   echo
 
   exit 1

--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -8066,6 +8066,232 @@ public abstract class AnthropicClientExtensionsTestsBase
         Assert.Equal(new Uri("https://example.com/eiffel"), annotation.Url);
     }
 
+    [Fact]
+    public void WithCacheControl_SetsAdditionalProperty()
+    {
+        var content = new TextContent("Hello, world!");
+
+        content.WithCacheControl(Anthropic.Models.Messages.Ttl.Ttl5m);
+
+        Assert.NotNull(content.AdditionalProperties);
+        var cacheControl = content.GetCacheControl();
+        Assert.NotNull(cacheControl);
+        Assert.True(cacheControl.Ttl == Anthropic.Models.Messages.Ttl.Ttl5m);
+    }
+
+    [Fact]
+    public void WithCacheControl_CacheControlEphemeral_SetsAdditionalProperty()
+    {
+        var content = new TextContent("Hello, world!");
+        var cacheControl = new Anthropic.Models.Messages.CacheControlEphemeral
+        {
+            Ttl = Anthropic.Models.Messages.Ttl.Ttl1h,
+        };
+
+        content.WithCacheControl(cacheControl);
+
+        var retrieved = content.GetCacheControl();
+        Assert.NotNull(retrieved);
+        Assert.True(retrieved.Ttl == Anthropic.Models.Messages.Ttl.Ttl1h);
+    }
+
+    [Fact]
+    public void WithCacheControl_Null_RemovesCacheControl()
+    {
+        var content = new TextContent("Hello, world!");
+        content.WithCacheControl(Anthropic.Models.Messages.Ttl.Ttl5m);
+
+        Assert.NotNull(content.GetCacheControl());
+
+        content.WithCacheControl((Anthropic.Models.Messages.CacheControlEphemeral?)null);
+
+        Assert.Null(content.GetCacheControl());
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_WithCacheControlOnSystemMessage()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Hello"
+                    }]
+                }],
+                "max_tokens": 1024,
+                "system": [{
+                    "type": "text",
+                    "text": "You are a helpful assistant.",
+                    "cache_control": {
+                        "type": "ephemeral",
+                        "ttl": "1h"
+                    }
+                }]
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_cache_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "Hello!"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        var systemContent = new TextContent("You are a helpful assistant.").WithCacheControl(
+            Anthropic.Models.Messages.Ttl.Ttl1h
+        );
+
+        List<ChatMessage> messages =
+        [
+            new(ChatRole.System, [systemContent]),
+            new(ChatRole.User, "Hello"),
+        ];
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            messages,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_WithCacheControlOnUserMessage()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "What is the meaning of life?",
+                        "cache_control": {
+                            "type": "ephemeral",
+                            "ttl": "5m"
+                        }
+                    }]
+                }],
+                "max_tokens": 1024
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_cache_02",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "42"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 15,
+                    "output_tokens": 3
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        var userContent = new TextContent("What is the meaning of life?").WithCacheControl(
+            Anthropic.Models.Messages.Ttl.Ttl5m
+        );
+
+        List<ChatMessage> messages = [new(ChatRole.User, [userContent])];
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            messages,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_WithCacheControlOnImage()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                        },
+                        "cache_control": {
+                            "type": "ephemeral",
+                            "ttl": "1h"
+                        }
+                    }, {
+                        "type": "text",
+                        "text": "What do you see?"
+                    }]
+                }],
+                "max_tokens": 1024
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_cache_03",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "I see a small image."
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 10
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        var imageContent = new DataContent(
+            "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+            "image/png"
+        ).WithCacheControl(Anthropic.Models.Messages.Ttl.Ttl1h);
+
+        List<ChatMessage> messages =
+        [
+            new(ChatRole.User, [imageContent, new TextContent("What do you see?")]),
+        ];
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            messages,
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
+
     protected sealed class VerbatimHttpHandler(string expectedRequest, string actualResponse)
         : HttpMessageHandler
     {

--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -4090,6 +4090,92 @@ public abstract class AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetStreamingResponseAsync_WithThinkingBlockMissingInitialSignature_DoesNotThrow()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Analyze this problem"
+                    }]
+                }],
+                "stream": true
+            }
+            """,
+            actualResponse: """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_thinking_stream_02","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me analyze this..."}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_456"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Based on my analysis"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":1}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":10}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (
+            var update in chatClient.GetStreamingResponseAsync(
+                "Analyze this problem",
+                new(),
+                TestContext.Current.CancellationToken
+            )
+        )
+        {
+            updates.Add(update);
+        }
+
+        Assert.NotEmpty(updates);
+        var reasoningUpdates = updates
+            .Where(u => u.Contents.Any(c => c is TextReasoningContent))
+            .ToList();
+        Assert.NotEmpty(reasoningUpdates);
+
+        var allReasoningContent = reasoningUpdates
+            .SelectMany(u => u.Contents.OfType<TextReasoningContent>())
+            .ToList();
+        Assert.Contains(
+            allReasoningContent,
+            static content => content.Text == string.Empty && content.ProtectedData is null
+        );
+        Assert.Contains(
+            allReasoningContent,
+            static content => content.Text == "Let me analyze this..."
+        );
+        Assert.Contains(allReasoningContent, static content => content.ProtectedData == "sig_456");
+    }
+
+    [Fact]
     public async Task GetStreamingResponseAsync_WithRedactedThinkingBlockInStream()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic/AIContentCacheExtensions.cs
+++ b/src/Anthropic/AIContentCacheExtensions.cs
@@ -1,0 +1,104 @@
+using Anthropic.Models.Messages;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+
+namespace Microsoft.Extensions.AI;
+
+/// <summary>
+/// Extension methods for configuring Anthropic prompt caching on <see cref="AIContent"/> instances.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Prompt caching allows you to cache frequently used context between API calls, reducing latency
+/// and costs for repetitive workloads. Cache breakpoints are placed at the END of content blocks
+/// that have cache control set.
+/// </para>
+/// <para>
+/// These extensions are only effective when used with the <see cref="IChatClient"/> returned by
+/// <see cref="AnthropicClientExtensions.AsIChatClient"/>. Other implementations will ignore the cache control settings.
+/// </para>
+/// </remarks>
+public static class AIContentCacheExtensions
+{
+    private const string CacheControlKey = "anthropic:cache_control";
+
+    /// <summary>
+    /// Configures Anthropic prompt caching on this content block.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="AIContent"/>.</typeparam>
+    /// <param name="content">The content to configure caching for.</param>
+    /// <param name="cacheControl">
+    /// The cache control configuration. Pass <see langword="null"/> to remove any existing cache control.
+    /// </param>
+    /// <returns>The same <paramref name="content"/> instance for method chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// The cache breakpoint is placed at the END of this content block. All content up to and including
+    /// this block will be cached together.
+    /// </para>
+    /// <para>
+    /// For optimal caching in agentic loops, place cache breakpoints on:
+    /// <list type="bullet">
+    ///   <item>System prompts (use <see cref="Ttl.Ttl1h"/> for stable prompts)</item>
+    ///   <item>The last content block before the current turn (use <see cref="Ttl.Ttl5m"/>)</item>
+    ///   <item>Large tool results that won't change</item>
+    /// </list>
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var systemContent = new TextContent(systemPrompt).WithCacheControl(new CacheControlEphemeral { Ttl = Ttl.Ttl1h });
+    /// chatMessages.Add(new ChatMessage(ChatRole.System, [systemContent]));
+    /// </code>
+    /// </example>
+    public static T WithCacheControl<T>(this T content, CacheControlEphemeral? cacheControl)
+        where T : AIContent
+    {
+        if (cacheControl is null)
+        {
+            content.AdditionalProperties?.Remove(CacheControlKey);
+        }
+        else
+        {
+            (content.AdditionalProperties ??= [])[CacheControlKey] = cacheControl;
+        }
+
+        return content;
+    }
+
+    /// <summary>
+    /// Configures Anthropic prompt caching on this content block with the specified TTL.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="AIContent"/>.</typeparam>
+    /// <param name="content">The content to configure caching for.</param>
+    /// <param name="ttl">
+    /// The time-to-live for the cache. Use <see cref="Ttl.Ttl5m"/> (5 minutes) for dynamic content
+    /// or <see cref="Ttl.Ttl1h"/> (1 hour) for stable content like system prompts.
+    /// Pass <see langword="null"/> for the default TTL (5 minutes).
+    /// </param>
+    /// <returns>The same <paramref name="content"/> instance for method chaining.</returns>
+    /// <example>
+    /// <code>
+    /// // Cache system prompt for 1 hour
+    /// var systemContent = new TextContent(systemPrompt).WithCacheControl(Ttl.Ttl1h);
+    ///
+    /// // Cache conversation context for 5 minutes (default)
+    /// var lastMessage = messages[^1].Contents.Last();
+    /// lastMessage.WithCacheControl(Ttl.Ttl5m);
+    /// </code>
+    /// </example>
+    public static T WithCacheControl<T>(this T content, Ttl? ttl)
+        where T : AIContent => content.WithCacheControl(new CacheControlEphemeral { Ttl = ttl });
+
+    /// <summary>
+    /// Gets the cache control configuration for this content block, if any.
+    /// </summary>
+    /// <param name="content">The content to check.</param>
+    /// <returns>
+    /// The <see cref="CacheControlEphemeral"/> if configured, or <see langword="null"/> if no cache control is set.
+    /// </returns>
+    internal static CacheControlEphemeral? GetCacheControl(this AIContent content) =>
+        content.AdditionalProperties?.TryGetValue(CacheControlKey, out var cc) == true
+            ? cc as CacheControlEphemeral
+            : null;
+}

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -823,7 +823,8 @@ public static class AnthropicClientExtensions
                                 break;
 
                             case TextContent tc:
-                                (systemMessages ??= []).Add(new() { Text = tc.Text });
+                                var block = new TextBlockParam { Text = tc.Text };
+                                (systemMessages ??= []).Add(WithCacheControlFrom(block, tc));
                                 break;
                         }
                     }
@@ -848,43 +849,59 @@ public static class AnthropicClientExtensions
                                 text = text.TrimEnd();
                                 if (!string.IsNullOrWhiteSpace(text))
                                 {
-                                    contents.Add(new TextBlockParam() { Text = text });
+                                    contents.Add(
+                                        WithCacheControlFrom(
+                                            new TextBlockParam() { Text = text },
+                                            tc
+                                        )
+                                    );
                                 }
                             }
                             else if (!string.IsNullOrWhiteSpace(text))
                             {
-                                contents.Add(new TextBlockParam() { Text = text });
+                                contents.Add(
+                                    WithCacheControlFrom(new TextBlockParam() { Text = text }, tc)
+                                );
                             }
                             break;
 
                         case TextReasoningContent trc when !string.IsNullOrEmpty(trc.Text):
                             contents.Add(
-                                new ThinkingBlockParam()
-                                {
-                                    Thinking = trc.Text,
-                                    Signature = trc.ProtectedData ?? string.Empty,
-                                }
+                                WithCacheControlFrom(
+                                    new ThinkingBlockParam()
+                                    {
+                                        Thinking = trc.Text,
+                                        Signature = trc.ProtectedData ?? string.Empty,
+                                    },
+                                    trc
+                                )
                             );
                             break;
 
                         case TextReasoningContent trc when !string.IsNullOrEmpty(trc.ProtectedData):
                             contents.Add(
-                                new RedactedThinkingBlockParam() { Data = trc.ProtectedData! }
+                                WithCacheControlFrom(
+                                    new RedactedThinkingBlockParam() { Data = trc.ProtectedData! },
+                                    trc
+                                )
                             );
                             break;
 
                         case DataContent dc when dc.HasTopLevelMediaType("image"):
                             contents.Add(
-                                new ImageBlockParam()
-                                {
-                                    Source = new(
-                                        new Base64ImageSource()
-                                        {
-                                            Data = dc.Base64Data.ToString(),
-                                            MediaType = dc.MediaType,
-                                        }
-                                    ),
-                                }
+                                WithCacheControlFrom(
+                                    new ImageBlockParam()
+                                    {
+                                        Source = new(
+                                            new Base64ImageSource()
+                                            {
+                                                Data = dc.Base64Data.ToString(),
+                                                MediaType = dc.MediaType,
+                                            }
+                                        ),
+                                    },
+                                    dc
+                                )
                             );
                             break;
 
@@ -895,35 +912,49 @@ public static class AnthropicClientExtensions
                                 StringComparison.OrdinalIgnoreCase
                             ):
                             contents.Add(
-                                new DocumentBlockParam()
-                                {
-                                    Source = new(
-                                        new Base64PdfSource() { Data = dc.Base64Data.ToString() }
-                                    ),
-                                }
+                                WithCacheControlFrom(
+                                    new DocumentBlockParam()
+                                    {
+                                        Source = new(
+                                            new Base64PdfSource()
+                                            {
+                                                Data = dc.Base64Data.ToString(),
+                                            }
+                                        ),
+                                    },
+                                    dc
+                                )
                             );
                             break;
 
                         case DataContent dc when dc.HasTopLevelMediaType("text"):
                             contents.Add(
-                                new DocumentBlockParam()
-                                {
-                                    Source = new(
-                                        new PlainTextSource()
-                                        {
-                                            Data = Encoding.UTF8.GetString(dc.Data.ToArray()),
-                                        }
-                                    ),
-                                }
+                                WithCacheControlFrom(
+                                    new DocumentBlockParam()
+                                    {
+                                        Source = new(
+                                            new PlainTextSource()
+                                            {
+                                                Data = Encoding.UTF8.GetString(dc.Data.ToArray()),
+                                            }
+                                        ),
+                                    },
+                                    dc
+                                )
                             );
                             break;
 
                         case UriContent uc when uc.HasTopLevelMediaType("image"):
                             contents.Add(
-                                new ImageBlockParam()
-                                {
-                                    Source = new(new UrlImageSource() { Url = uc.Uri.AbsoluteUri }),
-                                }
+                                WithCacheControlFrom(
+                                    new ImageBlockParam()
+                                    {
+                                        Source = new(
+                                            new UrlImageSource() { Url = uc.Uri.AbsoluteUri }
+                                        ),
+                                    },
+                                    uc
+                                )
                             );
                             break;
 
@@ -934,33 +965,41 @@ public static class AnthropicClientExtensions
                                 StringComparison.OrdinalIgnoreCase
                             ):
                             contents.Add(
-                                new DocumentBlockParam()
-                                {
-                                    Source = new(new UrlPdfSource() { Url = uc.Uri.AbsoluteUri }),
-                                }
+                                WithCacheControlFrom(
+                                    new DocumentBlockParam()
+                                    {
+                                        Source = new(
+                                            new UrlPdfSource() { Url = uc.Uri.AbsoluteUri }
+                                        ),
+                                    },
+                                    uc
+                                )
                             );
                             break;
 
                         case FunctionCallContent fcc:
                             contents.Add(
-                                new ToolUseBlockParam()
-                                {
-                                    ID = fcc.CallId,
-                                    Name = fcc.Name,
-                                    Input =
-                                        fcc.Arguments?.ToDictionary(
-                                            e => e.Key,
-                                            e =>
-                                                e.Value is JsonElement je
-                                                    ? je
-                                                    : JsonSerializer.SerializeToElement(
-                                                        e.Value,
-                                                        AIJsonUtilities.DefaultOptions.GetTypeInfo(
-                                                            typeof(object)
+                                WithCacheControlFrom(
+                                    new ToolUseBlockParam()
+                                    {
+                                        ID = fcc.CallId,
+                                        Name = fcc.Name,
+                                        Input =
+                                            fcc.Arguments?.ToDictionary(
+                                                e => e.Key,
+                                                e =>
+                                                    e.Value is JsonElement je
+                                                        ? je
+                                                        : JsonSerializer.SerializeToElement(
+                                                            e.Value,
+                                                            AIJsonUtilities.DefaultOptions.GetTypeInfo(
+                                                                typeof(object)
+                                                            )
                                                         )
-                                                    )
-                                        ) ?? [],
-                                }
+                                            ) ?? [],
+                                    },
+                                    fcc
+                                )
                             );
                             break;
 
@@ -1104,12 +1143,15 @@ public static class AnthropicClientExtensions
                             }
 
                             contents.Add(
-                                new ToolResultBlockParam()
-                                {
-                                    ToolUseID = frc.CallId,
-                                    IsError = frc.Exception is not null,
-                                    Content = result,
-                                }
+                                WithCacheControlFrom(
+                                    new ToolResultBlockParam()
+                                    {
+                                        ToolUseID = frc.CallId,
+                                        IsError = frc.Exception is not null,
+                                        Content = result,
+                                    },
+                                    frc
+                                )
                             );
                             break;
                     }
@@ -1130,6 +1172,33 @@ public static class AnthropicClientExtensions
             }
 
             return messageParams;
+        }
+
+        /// <summary>
+        /// Applies cache control from an <see cref="AIContent"/> to a content block param if configured.
+        /// </summary>
+        /// <remarks>
+        /// Note: ThinkingBlockParam and RedactedThinkingBlockParam do not support cache control.
+        /// </remarks>
+        private static T WithCacheControlFrom<T>(T block, AIContent content)
+            where T : class
+        {
+            var cacheControl = content.GetCacheControl();
+            if (cacheControl is null)
+            {
+                return block;
+            }
+
+            return block switch
+            {
+                TextBlockParam tb => (tb with { CacheControl = cacheControl }) as T ?? block,
+                ImageBlockParam ib => (ib with { CacheControl = cacheControl }) as T ?? block,
+                DocumentBlockParam db => (db with { CacheControl = cacheControl }) as T ?? block,
+                ToolUseBlockParam tub => (tub with { CacheControl = cacheControl }) as T ?? block,
+                ToolResultBlockParam trb => (trb with { CacheControl = cacheControl }) as T
+                    ?? block,
+                _ => block,
+            };
         }
 
         private MessageCreateParams GetMessageCreateParams(

--- a/src/Anthropic/Models/Beta/Messages/BetaThinkingBlock.cs
+++ b/src/Anthropic/Models/Beta/Messages/BetaThinkingBlock.cs
@@ -16,7 +16,9 @@ public sealed record class BetaThinkingBlock : JsonModel
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNotNullClass<string>("signature");
+            // Some APIs are advertised as Anthropic-compatible but erroneously omit the `signature` field in the response.
+            // This is a bug in the API itself, although we can handle it fairly easily here, so we do.
+            return this._rawData.GetNullableClass<string>("signature") ?? string.Empty;
         }
         init { this._rawData.Set("signature", value); }
     }

--- a/src/Anthropic/Models/Messages/ThinkingBlock.cs
+++ b/src/Anthropic/Models/Messages/ThinkingBlock.cs
@@ -16,7 +16,9 @@ public sealed record class ThinkingBlock : JsonModel
         get
         {
             this._rawData.Freeze();
-            return this._rawData.GetNotNullClass<string>("signature");
+            // Some APIs are advertised as Anthropic-compatible but erroneously omit the `signature` field in the response.
+            // This is a bug in the API itself, although we can handle it fairly easily here, so we do.
+            return this._rawData.GetNullableClass<string>("signature") ?? string.Empty;
         }
         init { this._rawData.Set("signature", value); }
     }

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -554,7 +554,8 @@ public static class AnthropicBetaClientExtensions
                                 break;
 
                             case TextContent tc:
-                                (systemMessages ??= []).Add(new() { Text = tc.Text });
+                                var block = new BetaTextBlockParam { Text = tc.Text };
+                                (systemMessages ??= []).Add(WithCacheControlFrom(block, tc));
                                 break;
                         }
                     }
@@ -580,43 +581,65 @@ public static class AnthropicBetaClientExtensions
                                 text = text.TrimEnd();
                                 if (!string.IsNullOrWhiteSpace(text))
                                 {
-                                    contents.Add(new BetaTextBlockParam() { Text = text });
+                                    contents.Add(
+                                        WithCacheControlFrom(
+                                            new BetaTextBlockParam() { Text = text },
+                                            tc
+                                        )
+                                    );
                                 }
                             }
                             else if (!string.IsNullOrWhiteSpace(text))
                             {
-                                contents.Add(new BetaTextBlockParam() { Text = text });
+                                contents.Add(
+                                    WithCacheControlFrom(
+                                        new BetaTextBlockParam() { Text = text },
+                                        tc
+                                    )
+                                );
                             }
                             break;
 
                         case TextReasoningContent trc when !string.IsNullOrEmpty(trc.Text):
                             contents.Add(
-                                new BetaThinkingBlockParam()
-                                {
-                                    Thinking = trc.Text,
-                                    Signature = trc.ProtectedData ?? string.Empty,
-                                }
+                                WithCacheControlFrom(
+                                    new BetaThinkingBlockParam()
+                                    {
+                                        Thinking = trc.Text,
+                                        Signature = trc.ProtectedData ?? string.Empty,
+                                    },
+                                    trc
+                                )
                             );
                             break;
 
                         case TextReasoningContent trc when !string.IsNullOrEmpty(trc.ProtectedData):
                             contents.Add(
-                                new BetaRedactedThinkingBlockParam() { Data = trc.ProtectedData! }
+                                WithCacheControlFrom(
+                                    new BetaRedactedThinkingBlockParam()
+                                    {
+                                        Data = trc.ProtectedData!,
+                                    },
+                                    trc
+                                )
                             );
                             break;
 
                         case DataContent dc when dc.HasTopLevelMediaType("image"):
                             contents.Add(
-                                new BetaImageBlockParam()
-                                {
-                                    Source = new(
-                                        new BetaBase64ImageSource()
-                                        {
-                                            Data = dc.Base64Data.ToString(),
-                                            MediaType = dc.MediaType,
-                                        }
-                                    ),
-                                }
+                                WithCacheControlFrom(
+                                    new BetaImageBlockParam()
+                                    {
+                                        Source = new(
+                                            new BetaBase64ImageSource()
+                                            {
+                                                Data = dc.Base64Data.ToString(),
+                                                MediaType = dc.MediaType,
+                                            }
+                                        ),
+                                    },
+                                    dc
+                                )
                             );
                             break;
 
@@ -627,44 +650,53 @@ public static class AnthropicBetaClientExtensions
                                 StringComparison.OrdinalIgnoreCase
                             ):
                             contents.Add(
-                                new BetaRequestDocumentBlock()
-                                {
-                                    Source = new(
-                                        new BetaBase64PdfSource()
-                                        {
-                                            Data = dc.Base64Data.ToString(),
-                                        }
-                                    ),
-                                }
+                                WithCacheControlFrom(
+                                    new BetaRequestDocumentBlock()
+                                    {
+                                        Source = new(
+                                            new BetaBase64PdfSource()
+                                            {
+                                                Data = dc.Base64Data.ToString(),
+                                            }
+                                        ),
+                                    },
+                                    dc
+                                )
                             );
                             break;
 
                         case DataContent dc when dc.HasTopLevelMediaType("text"):
                             contents.Add(
-                                new BetaRequestDocumentBlock()
-                                {
-                                    Source = new(
-                                        new BetaPlainTextSource()
-                                        {
+                                WithCacheControlFrom(
+                                    new BetaRequestDocumentBlock()
+                                    {
+                                        Source = new(
+                                            new BetaPlainTextSource()
+                                            {
 #if NET
-                                            Data = Encoding.UTF8.GetString(dc.Data.Span),
+                                                Data = Encoding.UTF8.GetString(dc.Data.Span),
 #else
-                                            Data = Encoding.UTF8.GetString(dc.Data.ToArray()),
+                                                Data = Encoding.UTF8.GetString(dc.Data.ToArray()),
 #endif
-                                        }
-                                    ),
-                                }
+                                            }
+                                        ),
+                                    },
+                                    dc
+                                )
                             );
                             break;
 
                         case UriContent uc when uc.HasTopLevelMediaType("image"):
                             contents.Add(
-                                new BetaImageBlockParam()
-                                {
-                                    Source = new(
-                                        new BetaUrlImageSource() { Url = uc.Uri.AbsoluteUri }
-                                    ),
-                                }
+                                WithCacheControlFrom(
+                                    new BetaImageBlockParam()
+                                    {
+                                        Source = new(
+                                            new BetaUrlImageSource() { Url = uc.Uri.AbsoluteUri }
+                                        ),
+                                    },
+                                    uc
+                                )
                             );
                             break;
 
@@ -675,44 +707,53 @@ public static class AnthropicBetaClientExtensions
                                 StringComparison.OrdinalIgnoreCase
                             ):
                             contents.Add(
-                                new BetaRequestDocumentBlock()
-                                {
-                                    Source = new(
-                                        new BetaUrlPdfSource() { Url = uc.Uri.AbsoluteUri }
-                                    ),
-                                }
+                                WithCacheControlFrom(
+                                    new BetaRequestDocumentBlock()
+                                    {
+                                        Source = new(
+                                            new BetaUrlPdfSource() { Url = uc.Uri.AbsoluteUri }
+                                        ),
+                                    },
+                                    uc
+                                )
                             );
                             break;
 
                         case HostedFileContent fc:
                             contents.Add(
-                                new BetaRequestDocumentBlock()
-                                {
-                                    Source = new(new BetaFileDocumentSource(fc.FileId)),
-                                }
+                                WithCacheControlFrom(
+                                    new BetaRequestDocumentBlock()
+                                    {
+                                        Source = new(new BetaFileDocumentSource(fc.FileId)),
+                                    },
+                                    fc
+                                )
                             );
                             break;
 
                         case FunctionCallContent fcc:
                             contents.Add(
-                                new BetaToolUseBlockParam()
-                                {
-                                    ID = fcc.CallId,
-                                    Name = fcc.Name,
-                                    Input =
-                                        fcc.Arguments?.ToDictionary(
-                                            e => e.Key,
-                                            e =>
-                                                e.Value is JsonElement je
-                                                    ? je
-                                                    : JsonSerializer.SerializeToElement(
-                                                        e.Value,
-                                                        AIJsonUtilities.DefaultOptions.GetTypeInfo(
-                                                            typeof(object)
+                                WithCacheControlFrom(
+                                    new BetaToolUseBlockParam()
+                                    {
+                                        ID = fcc.CallId,
+                                        Name = fcc.Name,
+                                        Input =
+                                            fcc.Arguments?.ToDictionary(
+                                                e => e.Key,
+                                                e =>
+                                                    e.Value is JsonElement je
+                                                        ? je
+                                                        : JsonSerializer.SerializeToElement(
+                                                            e.Value,
+                                                            AIJsonUtilities.DefaultOptions.GetTypeInfo(
+                                                                typeof(object)
+                                                            )
                                                         )
-                                                    )
-                                        ) ?? [],
-                                }
+                                            ) ?? [],
+                                    },
+                                    fcc
+                                )
                             );
                             break;
 
@@ -865,12 +906,15 @@ public static class AnthropicBetaClientExtensions
                             }
 
                             contents.Add(
-                                new BetaToolResultBlockParam()
-                                {
-                                    ToolUseID = frc.CallId,
-                                    IsError = frc.Exception is not null,
-                                    Content = result,
-                                }
+                                WithCacheControlFrom(
+                                    new BetaToolResultBlockParam()
+                                    {
+                                        ToolUseID = frc.CallId,
+                                        IsError = frc.Exception is not null,
+                                        Content = result,
+                                    },
+                                    frc
+                                )
                             );
                             break;
                     }
@@ -891,6 +935,51 @@ public static class AnthropicBetaClientExtensions
             }
 
             return messageParams;
+        }
+
+        /// <summary>
+        /// Applies cache control from an <see cref="AIContent"/> to a beta content block param if configured.
+        /// </summary>
+        /// <remarks>
+        /// Converts from <see cref="Anthropic.Models.Messages.CacheControlEphemeral"/> (used by the extension)
+        /// to <see cref="BetaCacheControlEphemeral"/> (used by the beta API).
+        /// Note: BetaThinkingBlockParam and BetaRedactedThinkingBlockParam do not support cache control.
+        /// </remarks>
+        private static T WithCacheControlFrom<T>(T block, AIContent content)
+            where T : class
+        {
+            var cacheControl = content.GetCacheControl();
+            if (cacheControl is null)
+            {
+                return block;
+            }
+
+            // Convert non-beta CacheControlEphemeral to BetaCacheControlEphemeral
+            // Note: Ttl enum exists in both namespaces, using fully qualified names to disambiguate
+            var betaCacheControl = new BetaCacheControlEphemeral
+            {
+                Ttl = cacheControl.Ttl?.Value() switch
+                {
+                    Anthropic.Models.Messages.Ttl.Ttl5m => Anthropic.Models.Beta.Messages.Ttl.Ttl5m,
+                    Anthropic.Models.Messages.Ttl.Ttl1h => Anthropic.Models.Beta.Messages.Ttl.Ttl1h,
+                    _ => null,
+                },
+            };
+
+            return block switch
+            {
+                BetaTextBlockParam tb => (tb with { CacheControl = betaCacheControl }) as T
+                    ?? block,
+                BetaImageBlockParam ib => (ib with { CacheControl = betaCacheControl }) as T
+                    ?? block,
+                BetaRequestDocumentBlock db => (db with { CacheControl = betaCacheControl }) as T
+                    ?? block,
+                BetaToolUseBlockParam tub => (tub with { CacheControl = betaCacheControl }) as T
+                    ?? block,
+                BetaToolResultBlockParam trb => (trb with { CacheControl = betaCacheControl }) as T
+                    ?? block,
+                _ => block,
+            };
         }
 
         private MessageCreateParams GetMessageCreateParams(


### PR DESCRIPTION
## Summary
- stop the Microsoft.Extensions.AI Anthropic adapters from throwing when a streaming thinking block omits the initial `signature`
- read `signature` from raw JSON opportunistically for thinking blocks in both the standard and beta adapters
- add regression coverage for providers that emit the signature later via `signature_delta`

## Why
MiniMax''s Anthropic-compatible streaming API sends a `thinking` content block without an initial `signature`, then emits the signature later as a `signature_delta`. The current adapters access `thinking.Signature` eagerly, which throws before the stream can continue.

This change keeps the existing `signature_delta` handling, but avoids assuming the initial block always includes a signature.

## Testing
- `dotnet test src/Anthropic.Tests/Anthropic.Tests.csproj -c Release --no-restore --filter "GetStreamingResponseAsync_WithThinkingBlockMissingInitialSignature_DoesNotThrow|GetStreamingResponseAsync_WithThinkingBlockInStream|GetStreamingResponseAsync_WithSignatureDeltaInStream"`