### PR TITLE
fix(client): map HostedFileContent with image media type to image block

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientBetaExtensionsTests.cs
+++ b/src/Anthropic.Tests/AnthropicClientBetaExtensionsTests.cs
@@ -673,6 +673,7 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
     [Fact]
     public async Task GetResponseAsync_WithFunctionResultContent_HostedFileContent()
     {
+        IEnumerable<string>? capturedBetaHeaders = null;
         VerbatimHttpHandler handler = new(
             expectedRequest: """
             {
@@ -730,7 +731,11 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
                 }
             }
             """
-        );
+        )
+        {
+            OnRequestHeaders = headers =>
+                headers.TryGetValues("anthropic-beta", out capturedBetaHeaders),
+        };
 
         IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
 
@@ -759,6 +764,111 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
             TestContext.Current.CancellationToken
         );
         Assert.NotNull(response);
+        Assert.NotNull(capturedBetaHeaders);
+        Assert.Contains("files-api-2025-04-14", capturedBetaHeaders);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_WithFunctionResultContent_HostedFileContent_Image()
+    {
+        IEnumerable<string>? capturedBetaHeaders = null;
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                            "text": "Get image"
+                        }]
+                    },
+                    {
+                        "role": "assistant",
+                        "content": [{
+                            "type": "tool_use",
+                            "id": "tool_image",
+                            "name": "image_tool",
+                            "input": {}
+                        }]
+                    },
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "tool_result",
+                            "tool_use_id": "tool_image",
+                            "is_error": false,
+                            "content": [{
+                                "type": "image",
+                                "source": {
+                                    "type": "file",
+                                    "file_id": "file_abc123"
+                                }
+                            }]
+                        }]
+                    }
+                ]
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_image_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "Image received"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 28,
+                    "output_tokens": 7
+                }
+            }
+            """
+        )
+        {
+            OnRequestHeaders = headers =>
+                headers.TryGetValues("anthropic-beta", out capturedBetaHeaders),
+        };
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        List<ChatMessage> messages =
+        [
+            new ChatMessage(ChatRole.User, "Get image"),
+            new ChatMessage(
+                ChatRole.Assistant,
+                [
+                    new FunctionCallContent(
+                        "tool_image",
+                        "image_tool",
+                        new Dictionary<string, object?>()
+                    ),
+                ]
+            ),
+            new ChatMessage(
+                ChatRole.User,
+                [
+                    new FunctionResultContent(
+                        "tool_image",
+                        new HostedFileContent("file_abc123") { MediaType = "image/png" }
+                    ),
+                ]
+            ),
+        ];
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            messages,
+            new(),
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+        Assert.NotNull(capturedBetaHeaders);
+        Assert.Contains("files-api-2025-04-14", capturedBetaHeaders);
     }
 
     [Fact]
@@ -789,6 +899,7 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
     [Fact]
     public async Task GetResponseAsync_WithHostedFileContent()
     {
+        IEnumerable<string>? capturedBetaHeaders = null;
         VerbatimHttpHandler handler = new(
             expectedRequest: """
             {
@@ -823,7 +934,11 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
                 }
             }
             """
-        );
+        )
+        {
+            OnRequestHeaders = headers =>
+                headers.TryGetValues("anthropic-beta", out capturedBetaHeaders),
+        };
 
         IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
 
@@ -835,43 +950,40 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
             TestContext.Current.CancellationToken
         );
         Assert.NotNull(response);
+        Assert.NotNull(capturedBetaHeaders);
+        Assert.Contains("files-api-2025-04-14", capturedBetaHeaders);
     }
 
     [Fact]
-    public async Task GetResponseAsync_WithRawRepresentationFactory()
+    public async Task GetResponseAsync_WithHostedFileContent_Image()
     {
+        IEnumerable<string>? capturedBetaHeaders = null;
         VerbatimHttpHandler handler = new(
             expectedRequest: """
             {
-                "max_tokens": 2048,
+                "max_tokens": 1024,
                 "model": "claude-haiku-4-5",
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": [{
-                            "type": "text",
-                            "text": "Preconfigured message"
-                        }]
-                    },
-                    {
-                        "role": "user",
-                        "content": [{
-                            "type": "text",
-                            "text": "New message"
-                        }]
-                    }
-                ]
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "image",
+                        "source": {
+                            "type": "file",
+                            "file_id": "file_abc123"
+                        }
+                    }]
+                }]
             }
             """,
             actualResponse: """
             {
-                "id": "msg_factory_01",
+                "id": "msg_hosted_image_01",
                 "type": "message",
                 "role": "assistant",
                 "model": "claude-haiku-4-5",
                 "content": [{
                     "type": "text",
-                    "text": "Response"
+                    "text": "I see an image."
                 }],
                 "stop_reason": "end_turn",
                 "usage": {
@@ -880,35 +992,25 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
                 }
             }
             """
-        );
+        )
+        {
+            OnRequestHeaders = headers =>
+                headers.TryGetValues("anthropic-beta", out capturedBetaHeaders),
+        };
 
         IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
 
-        ChatOptions options = new()
-        {
-            RawRepresentationFactory = _ => new MessageCreateParams()
-            {
-                MaxTokens = 2048,
-                Model = "claude-haiku-4-5",
-                Messages =
-                [
-                    new BetaMessageParam()
-                    {
-                        Role = Role.User,
-                        Content = new BetaMessageParamContent(
-                            [new BetaTextBlockParam() { Text = "Preconfigured message" }]
-                        ),
-                    },
-                ],
-            },
-        };
+        var hostedFile = new HostedFileContent("file_abc123") { MediaType = "image/png" };
 
         ChatResponse response = await chatClient.GetResponseAsync(
-            "New message",
-            options,
+            [new ChatMessage(ChatRole.User, [hostedFile])],
+            new(),
             TestContext.Current.CancellationToken
         );
         Assert.NotNull(response);
+        Assert.Equal("I see an image.", response.Text);
+        Assert.NotNull(capturedBetaHeaders);
+        Assert.Contains("files-api-2025-04-14", capturedBetaHeaders);
     }
 
     [Fact]
@@ -1899,6 +2001,80 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
 
         ChatResponse response = await chatClient.GetResponseAsync(
             "Use tool",
+            options,
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
+
+    [Fact]
+    public async Task GetResponseAsync_WithRawRepresentationFactory()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 2048,
+                "model": "claude-haiku-4-5",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                            "text": "Preconfigured message"
+                        }]
+                    },
+                    {
+                        "role": "user",
+                        "content": [{
+                            "type": "text",
+                            "text": "New message"
+                        }]
+                    }
+                ]
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_factory_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "Response"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 20,
+                    "output_tokens": 5
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        ChatOptions options = new()
+        {
+            RawRepresentationFactory = _ => new MessageCreateParams()
+            {
+                MaxTokens = 2048,
+                Model = "claude-haiku-4-5",
+                Messages =
+                [
+                    new BetaMessageParam()
+                    {
+                        Role = Role.User,
+                        Content = new BetaMessageParamContent(
+                            [new BetaTextBlockParam() { Text = "Preconfigured message" }]
+                        ),
+                    },
+                ],
+            },
+        };
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            "New message",
             options,
             TestContext.Current.CancellationToken
         );

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -232,12 +232,9 @@ public static class AnthropicBetaClientExtensions
 
             List<BetaMessageParam> messageParams = CreateMessageParams(
                 messages,
-                out List<BetaTextBlockParam>? systemMessages
+                out List<BetaTextBlockParam>? systemMessages,
+                out bool hasHostedFiles
             );
-            bool hasHostedFiles = messages
-                .SelectMany(m => m.Contents)
-                .OfType<HostedFileContent>()
-                .Any();
             MessageCreateParams createParams = GetMessageCreateParams(
                 messageParams,
                 systemMessages,
@@ -304,12 +301,9 @@ public static class AnthropicBetaClientExtensions
 
             List<BetaMessageParam> messageParams = CreateMessageParams(
                 messages,
-                out List<BetaTextBlockParam>? systemMessages
+                out List<BetaTextBlockParam>? systemMessages,
+                out bool hasHostedFiles
             );
-            bool hasHostedFiles = messages
-                .SelectMany(m => m.Contents)
-                .OfType<HostedFileContent>()
-                .Any();
             MessageCreateParams createParams = GetMessageCreateParams(
                 messageParams,
                 systemMessages,
@@ -535,11 +529,13 @@ public static class AnthropicBetaClientExtensions
 
         private static List<BetaMessageParam> CreateMessageParams(
             IEnumerable<ChatMessage> messages,
-            out List<BetaTextBlockParam>? systemMessages
+            out List<BetaTextBlockParam>? systemMessages,
+            out bool hasHostedFiles
         )
         {
             List<BetaMessageParam> messageParams = [];
             systemMessages = null;
+            hasHostedFiles = false;
 
             foreach (ChatMessage message in messages)
             {
@@ -684,7 +680,18 @@ public static class AnthropicBetaClientExtensions
                             );
                             break;
 
+                        case HostedFileContent fc when fc.HasTopLevelMediaType("image"):
+                            hasHostedFiles = true;
+                            contents.Add(
+                                new BetaImageBlockParam()
+                                {
+                                    Source = new(new BetaFileImageSource(fc.FileId)),
+                                }
+                            );
+                            break;
+
                         case HostedFileContent fc:
+                            hasHostedFiles = true;
                             contents.Add(
                                 new BetaRequestDocumentBlock()
                                 {
@@ -723,10 +730,12 @@ public static class AnthropicBetaClientExtensions
 
                                 string s => new(s),
 
-                                AIContent aiContent => new(ToResultBlocks([aiContent])),
+                                AIContent aiContent => new(
+                                    ToResultBlocks([aiContent], ref hasHostedFiles)
+                                ),
 
                                 IEnumerable<AIContent> aiContents => new(
-                                    ToResultBlocks(aiContents)
+                                    ToResultBlocks(aiContents, ref hasHostedFiles)
                                 ),
 
                                 _ => new(
@@ -738,24 +747,30 @@ public static class AnthropicBetaClientExtensions
                             };
 
                             static IReadOnlyList<Block> ToResultBlocks(
-                                IEnumerable<AIContent> aiContents
+                                IEnumerable<AIContent> aiContents,
+                                ref bool hasHostedFiles
                             )
                             {
                                 List<Block> blocks = [];
                                 foreach (AIContent ac in aiContents)
                                 {
-                                    blocks.Add(
-                                        ac switch
-                                        {
-                                            AIContent ai
-                                                when ai.RawRepresentation is Block rawBlock =>
-                                                rawBlock,
+                                    switch (ac)
+                                    {
+                                        case AIContent ai
+                                            when ai.RawRepresentation is Block rawBlock:
+                                            blocks.Add(rawBlock);
+                                            break;
 
-                                            TextContent tc => new Block(
-                                                new BetaTextBlockParam() { Text = tc.Text }
-                                            ),
+                                        case TextContent tc:
+                                            blocks.Add(
+                                                new Block(
+                                                    new BetaTextBlockParam() { Text = tc.Text }
+                                                )
+                                            );
+                                            break;
 
-                                            DataContent dc when dc.HasTopLevelMediaType("image") =>
+                                        case DataContent dc when dc.HasTopLevelMediaType("image"):
+                                            blocks.Add(
                                                 new Block(
                                                     new BetaImageBlockParam()
                                                     {
@@ -767,26 +782,33 @@ public static class AnthropicBetaClientExtensions
                                                             }
                                                         ),
                                                     }
-                                                ),
+                                                )
+                                            );
+                                            break;
 
-                                            DataContent dc
-                                                when string.Equals(
-                                                    dc.MediaType,
-                                                    "application/pdf",
-                                                    StringComparison.OrdinalIgnoreCase
-                                                ) => new Block(
-                                                new BetaRequestDocumentBlock()
-                                                {
-                                                    Source = new(
-                                                        new BetaBase64PdfSource()
-                                                        {
-                                                            Data = dc.Base64Data.ToString(),
-                                                        }
-                                                    ),
-                                                }
-                                            ),
+                                        case DataContent dc
+                                            when string.Equals(
+                                                dc.MediaType,
+                                                "application/pdf",
+                                                StringComparison.OrdinalIgnoreCase
+                                            ):
+                                            blocks.Add(
+                                                new Block(
+                                                    new BetaRequestDocumentBlock()
+                                                    {
+                                                        Source = new(
+                                                            new BetaBase64PdfSource()
+                                                            {
+                                                                Data = dc.Base64Data.ToString(),
+                                                            }
+                                                        ),
+                                                    }
+                                                )
+                                            );
+                                            break;
 
-                                            DataContent dc when dc.HasTopLevelMediaType("text") =>
+                                        case DataContent dc when dc.HasTopLevelMediaType("text"):
+                                            blocks.Add(
                                                 new Block(
                                                     new BetaRequestDocumentBlock()
                                                     {
@@ -805,9 +827,12 @@ public static class AnthropicBetaClientExtensions
                                                             }
                                                         ),
                                                     }
-                                                ),
+                                                )
+                                            );
+                                            break;
 
-                                            UriContent uc when uc.HasTopLevelMediaType("image") =>
+                                        case UriContent uc when uc.HasTopLevelMediaType("image"):
+                                            blocks.Add(
                                                 new Block(
                                                     new BetaImageBlockParam()
                                                     {
@@ -818,47 +843,76 @@ public static class AnthropicBetaClientExtensions
                                                             }
                                                         ),
                                                     }
-                                                ),
+                                                )
+                                            );
+                                            break;
 
-                                            UriContent uc
-                                                when string.Equals(
-                                                    uc.MediaType,
-                                                    "application/pdf",
-                                                    StringComparison.OrdinalIgnoreCase
-                                                ) => new Block(
-                                                new BetaRequestDocumentBlock()
-                                                {
-                                                    Source = new(
-                                                        new BetaUrlPdfSource()
-                                                        {
-                                                            Url = uc.Uri.AbsoluteUri,
-                                                        }
-                                                    ),
-                                                }
-                                            ),
+                                        case UriContent uc
+                                            when string.Equals(
+                                                uc.MediaType,
+                                                "application/pdf",
+                                                StringComparison.OrdinalIgnoreCase
+                                            ):
+                                            blocks.Add(
+                                                new Block(
+                                                    new BetaRequestDocumentBlock()
+                                                    {
+                                                        Source = new(
+                                                            new BetaUrlPdfSource()
+                                                            {
+                                                                Url = uc.Uri.AbsoluteUri,
+                                                            }
+                                                        ),
+                                                    }
+                                                )
+                                            );
+                                            break;
 
-                                            HostedFileContent fc => new Block(
-                                                new BetaRequestDocumentBlock()
-                                                {
-                                                    Source = new(
-                                                        new BetaFileDocumentSource(fc.FileId)
-                                                    ),
-                                                }
-                                            ),
+                                        case HostedFileContent fc
+                                            when fc.HasTopLevelMediaType("image"):
+                                            hasHostedFiles = true;
+                                            blocks.Add(
+                                                new Block(
+                                                    new BetaImageBlockParam()
+                                                    {
+                                                        Source = new(
+                                                            new BetaFileImageSource(fc.FileId)
+                                                        ),
+                                                    }
+                                                )
+                                            );
+                                            break;
 
-                                            _ => new Block(
-                                                new BetaTextBlockParam()
-                                                {
-                                                    Text = JsonSerializer.Serialize(
-                                                        ac,
-                                                        AIJsonUtilities.DefaultOptions.GetTypeInfo(
-                                                            typeof(object)
-                                                        )
-                                                    ),
-                                                }
-                                            ),
-                                        }
-                                    );
+                                        case HostedFileContent fc:
+                                            hasHostedFiles = true;
+                                            blocks.Add(
+                                                new Block(
+                                                    new BetaRequestDocumentBlock()
+                                                    {
+                                                        Source = new(
+                                                            new BetaFileDocumentSource(fc.FileId)
+                                                        ),
+                                                    }
+                                                )
+                                            );
+                                            break;
+
+                                        default:
+                                            blocks.Add(
+                                                new Block(
+                                                    new BetaTextBlockParam()
+                                                    {
+                                                        Text = JsonSerializer.Serialize(
+                                                            ac,
+                                                            AIJsonUtilities.DefaultOptions.GetTypeInfo(
+                                                                typeof(object)
+                                                            )
+                                                        ),
+                                                    }
+                                                )
+                                            );
+                                            break;
+                                    }
                                 }
 
                                 return blocks;


### PR DESCRIPTION
When HostedFileContent has an image MediaType (e.g. image/png), map it to `BetaImageBlockParam` instead of always using `BetaRequestDocumentBlock` to allows users to send hosted file images via MEAI abstractions without dropping down to `RawRepresentation` (break glass).

Applied in both user message content conversion and tool result content conversion paths.

Also fix another bug where we were not sending the beta header when the `HostedFileContent` was in a `FunctionResultContent`.