### PR TITLE
Update to M.E.AI.Abstractions 10.5.1

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -4857,13 +4857,13 @@ public abstract class AnthropicClientExtensionsTestsBase
         // Verify WebSearchToolResultContent
         var wsResult = Assert.IsType<WebSearchToolResultContent>(contents[1]);
         Assert.Equal("srvtoolu_ws_01", wsResult.CallId);
-        Assert.NotNull(wsResult.Results);
-        Assert.Equal(2, wsResult.Results.Count);
+        Assert.NotNull(wsResult.Outputs);
+        Assert.Equal(2, wsResult.Outputs.Count);
 
-        var firstResult = Assert.IsType<UriContent>(wsResult.Results[0]);
+        var firstResult = Assert.IsType<UriContent>(wsResult.Outputs[0]);
         Assert.Equal(new Uri("https://example.com/ai-news"), firstResult.Uri);
 
-        var secondResult = Assert.IsType<UriContent>(wsResult.Results[1]);
+        var secondResult = Assert.IsType<UriContent>(wsResult.Outputs[1]);
         Assert.Equal(new Uri("https://example.com/ai-research"), secondResult.Uri);
 
         // Verify text content
@@ -5034,9 +5034,9 @@ public abstract class AnthropicClientExtensionsTestsBase
 
         var wsResult = Assert.IsType<WebSearchToolResultContent>(contents[1]);
         Assert.Equal("srvtoolu_ws_err_01", wsResult.CallId);
-        Assert.NotNull(wsResult.Results);
-        Assert.Single(wsResult.Results);
-        var errorResult = Assert.IsType<ErrorContent>(wsResult.Results[0]);
+        Assert.NotNull(wsResult.Outputs);
+        Assert.Single(wsResult.Outputs);
+        var errorResult = Assert.IsType<ErrorContent>(wsResult.Outputs[0]);
         Assert.Equal("MaxUsesExceeded", errorResult.ErrorCode);
     }
 
@@ -7618,9 +7618,9 @@ public abstract class AnthropicClientExtensionsTestsBase
         var contents = response.Messages[0].Contents;
         var result = Assert.IsType<WebSearchToolResultContent>(contents[0]);
         Assert.Equal("srvtoolu_wf_01", result.CallId);
-        Assert.NotNull(result.Results);
-        Assert.Single(result.Results);
-        var uriContent = Assert.IsType<UriContent>(result.Results[0]);
+        Assert.NotNull(result.Outputs);
+        Assert.Single(result.Outputs);
+        var uriContent = Assert.IsType<UriContent>(result.Outputs[0]);
         Assert.Equal(new Uri("https://example.com/article.html"), uriContent.Uri);
         Assert.Equal("text/html", uriContent.MediaType);
     }
@@ -7863,10 +7863,10 @@ public abstract class AnthropicClientExtensionsTestsBase
 
         var wsResult = wsResultUpdates[0];
         Assert.Equal("srvtoolu_ws_stream_01", wsResult.CallId);
-        Assert.NotNull(wsResult.Results);
-        Assert.Single(wsResult.Results);
+        Assert.NotNull(wsResult.Outputs);
+        Assert.Single(wsResult.Outputs);
 
-        var uriContent = Assert.IsType<UriContent>(wsResult.Results[0]);
+        var uriContent = Assert.IsType<UriContent>(wsResult.Outputs[0]);
         Assert.Equal(new Uri("https://example.com/stream"), uriContent.Uri);
     }
 

--- a/src/Anthropic/Anthropic.csproj
+++ b/src/Anthropic/Anthropic.csproj
@@ -15,9 +15,9 @@
     <InternalsVisibleTo Include="Anthropic.Tests,PublicKey=002400000480000094000000060200000024000052534131000400000100010063a3c9395e3d40be5b18dc9c4104236f7a42b63f7fee034f73dcfdb09a677d5bb552f6ffe35d580da1195fd5098ee99affcd842ceeca7973611c3eae10bafa96159ecf8bdd0252ac670b49ffaefd8986a272897cf68b9b1b3e0372dcabff785d5c6c90eab31633416d812ad7f899cc70a2ffc6d869580694017cab7e8c97f4b6"/>
     <None Include="..\logo.png" Pack="true" PackagePath="\"/>
     <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
-    <PackageReference Include="System.Text.Json" Version="10.0.4"/>
+    <PackageReference Include="System.Text.Json" Version="10.0.6"/>
     <PackageReference Include="System.Net.ServerSentEvents" Version="10.0.1"/>
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.4.0"/>
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.5.1"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -1857,7 +1857,7 @@ public static class AnthropicClientExtensions
                     {
                         foreach (var result in searchResults)
                         {
-                            (wsrc.Results ??= []).Add(
+                            (wsrc.Outputs ??= []).Add(
                                 new UriContent(result.Url, InferMediaTypeFromExtension(result.Url))
                                 {
                                     RawRepresentation = result,
@@ -1867,7 +1867,7 @@ public static class AnthropicClientExtensions
                     }
                     else if (wsResult.Content.TryPickError(out var wsError))
                     {
-                        (wsrc.Results ??= []).Add(
+                        (wsrc.Outputs ??= []).Add(
                             new ErrorContent(null)
                             {
                                 ErrorCode = wsError.ErrorCode.Value().ToString(),
@@ -1888,7 +1888,7 @@ public static class AnthropicClientExtensions
 
                     if (wfResult.Content.TryPickWebFetchBlock(out var fetchBlock))
                     {
-                        (wfrc.Results ??= []).Add(
+                        (wfrc.Outputs ??= []).Add(
                             new UriContent(
                                 fetchBlock.Url,
                                 InferMediaTypeFromExtension(fetchBlock.Url)
@@ -1900,7 +1900,7 @@ public static class AnthropicClientExtensions
                     }
                     else if (wfResult.Content.TryPickWebFetchToolResultErrorBlock(out var wfError))
                     {
-                        (wfrc.Results ??= []).Add(
+                        (wfrc.Outputs ??= []).Add(
                             new ErrorContent(null)
                             {
                                 ErrorCode = wfError.ErrorCode.Value().ToString(),

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1821,7 +1821,7 @@ public static class AnthropicBetaClientExtensions
                     {
                         foreach (var result in searchResults)
                         {
-                            (wsrc.Results ??= []).Add(
+                            (wsrc.Outputs ??= []).Add(
                                 new UriContent(
                                     result.Url,
                                     AnthropicClientExtensions.InferMediaTypeFromExtension(
@@ -1836,7 +1836,7 @@ public static class AnthropicBetaClientExtensions
                     }
                     else if (wsResult.Content.TryPickError(out var wsError))
                     {
-                        (wsrc.Results ??= []).Add(
+                        (wsrc.Outputs ??= []).Add(
                             new ErrorContent(null)
                             {
                                 ErrorCode = wsError.ErrorCode.Value().ToString(),
@@ -1857,7 +1857,7 @@ public static class AnthropicBetaClientExtensions
 
                     if (wfResult.Content.TryPickBetaWebFetchBlock(out var fetchBlock))
                     {
-                        (wfrc.Results ??= []).Add(
+                        (wfrc.Outputs ??= []).Add(
                             new UriContent(
                                 fetchBlock.Url,
                                 AnthropicClientExtensions.InferMediaTypeFromExtension(
@@ -1873,7 +1873,7 @@ public static class AnthropicBetaClientExtensions
                         wfResult.Content.TryPickBetaWebFetchToolResultErrorBlock(out var wfError)
                     )
                     {
-                        (wfrc.Results ??= []).Add(
+                        (wfrc.Outputs ??= []).Add(
                             new ErrorContent(null)
                             {
                                 ErrorCode = wfError.ErrorCode.Value().ToString(),


### PR DESCRIPTION
Adopts the WebSearchToolResultContent.Results -> Outputs rename (aligning with CodeInterpreterToolResultContent.Outputs).