### PR TITLE
fix: preserve top-level json schema keywords

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientBetaExtensionsTests.cs
+++ b/src/Anthropic.Tests/AnthropicClientBetaExtensionsTests.cs
@@ -1099,6 +1099,92 @@ public class AnthropicClientBetaExtensionsTests : AnthropicClientExtensionsTests
     }
 
     [Fact]
+    public async Task GetResponseAsync_WithResponseFormatSchemaContainingDefs_PreservesDefs()
+    {
+        // Top-level JSON Schema keywords like $defs must survive forwarding to
+        // output_config.format.schema; otherwise $ref references become
+        // unresolvable and the server returns 400.
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Return JSON"
+                    }]
+                }],
+                "output_config": {
+                    "format": {
+                        "type": "json_schema",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "value": { "$ref": "#/$defs/Item" }
+                            },
+                            "required": ["value"],
+                            "$defs": {
+                                "Item": { "type": "string" }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_defs_beta_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "{\"value\":\"hello\"}"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        ChatOptions options = new()
+        {
+            ResponseFormat = ChatResponseFormat.ForJsonSchema(
+                JsonElement.Parse(
+                    """
+                    {
+                        "type": "object",
+                        "properties": {
+                            "value": { "$ref": "#/$defs/Item" }
+                        },
+                        "required": ["value"],
+                        "$defs": {
+                            "Item": { "type": "string" }
+                        }
+                    }
+                    """
+                ),
+                "result_with_defs"
+            ),
+        };
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            "Return JSON",
+            options,
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
+
+    [Fact]
     public async Task GetResponseAsync_WithNonEmptyMessageParams_EmptyMessages()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic.Tests/AnthropicClientExtensionsTests.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTests.cs
@@ -424,6 +424,92 @@ public class AnthropicClientExtensionsTests : AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetResponseAsync_WithResponseFormatSchemaContainingDefs_PreservesDefs()
+    {
+        // Top-level JSON Schema keywords like $defs must survive forwarding to
+        // output_config.format.schema; otherwise $ref references become
+        // unresolvable and the server returns 400.
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Return JSON"
+                    }]
+                }],
+                "output_config": {
+                    "format": {
+                        "type": "json_schema",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "value": { "$ref": "#/$defs/Item" }
+                            },
+                            "required": ["value"],
+                            "$defs": {
+                                "Item": { "type": "string" }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_defs_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "{\"value\":\"hello\"}"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 5
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        ChatOptions options = new()
+        {
+            ResponseFormat = ChatResponseFormat.ForJsonSchema(
+                JsonElement.Parse(
+                    """
+                    {
+                        "type": "object",
+                        "properties": {
+                            "value": { "$ref": "#/$defs/Item" }
+                        },
+                        "required": ["value"],
+                        "$defs": {
+                            "Item": { "type": "string" }
+                        }
+                    }
+                    """
+                ),
+                "result_with_defs"
+            ),
+        };
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            "Return JSON",
+            options,
+            TestContext.Current.CancellationToken
+        );
+        Assert.NotNull(response);
+    }
+
+    [Fact]
     public async Task GetResponseAsync_WithNonEmptyMessageParams_EmptyMessages()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -1263,30 +1263,33 @@ public static class AnthropicClientExtensions
                                 .GetOrCreateTransformedSchema(formatJson)
                                 .GetValueOrDefault();
                             if (
-                                schema.TryGetProperty("properties", out JsonElement properties)
+                                schema.ValueKind is JsonValueKind.Object
+                                && schema.TryGetProperty("properties", out JsonElement properties)
                                 && properties.ValueKind is JsonValueKind.Object
                                 && schema.TryGetProperty("required", out JsonElement required)
                                 && required.ValueKind is JsonValueKind.Array
                             )
                             {
+                                // Preserve all top-level schema keywords (e.g. $defs, definitions,
+                                // description, title) so $ref references remain resolvable; only
+                                // override type/additionalProperties to satisfy API requirements.
+                                var schemaDict = new Dictionary<string, JsonElement>(
+                                    StringComparer.Ordinal
+                                );
+                                foreach (JsonProperty p in schema.EnumerateObject())
+                                {
+                                    schemaDict[p.Name] = p.Value;
+                                }
+                                schemaDict["type"] = JsonElement.Parse("\"object\"");
+                                schemaDict["additionalProperties"] = JsonElement.Parse("false");
+
                                 createParams = createParams with
                                 {
                                     OutputConfig = (
                                         createParams.OutputConfig ?? new OutputConfig()
                                     ) with
                                     {
-                                        Format = new JsonOutputFormat()
-                                        {
-                                            Schema = new Dictionary<string, JsonElement>
-                                            {
-                                                ["type"] = JsonElement.Parse("\"object\""),
-                                                ["properties"] = properties,
-                                                ["required"] = required,
-                                                ["additionalProperties"] = JsonElement.Parse(
-                                                    "false"
-                                                ),
-                                            },
-                                        },
+                                        Format = new JsonOutputFormat() { Schema = schemaDict },
                                     },
                                 };
                             }

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -1270,7 +1270,7 @@ public static class AnthropicClientExtensions
                                 && required.ValueKind is JsonValueKind.Array
                             )
                             {
-                                // Preserve all top-level schema keywords (e.g. $defs, definitions,
+                                // Preserve all top-level schema keywords (e.g. $defs,
                                 // description, title) so $ref references remain resolvable; only
                                 // override type/additionalProperties to satisfy API requirements.
                                 var schemaDict = new Dictionary<string, JsonElement>(

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1134,10 +1134,7 @@ public static class AnthropicBetaClientExtensions
                                         createParams.OutputConfig ?? new BetaOutputConfig()
                                     ) with
                                     {
-                                        Format = new BetaJsonOutputFormat()
-                                        {
-                                            Schema = schemaDict,
-                                        },
+                                        Format = new BetaJsonOutputFormat() { Schema = schemaDict },
                                     },
                                 };
                             }

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1108,12 +1108,26 @@ public static class AnthropicBetaClientExtensions
                                 .JsonSchemaTransformCache.GetOrCreateTransformedSchema(formatJson)
                                 .GetValueOrDefault();
                             if (
-                                schema.TryGetProperty("properties", out JsonElement properties)
+                                schema.ValueKind is JsonValueKind.Object
+                                && schema.TryGetProperty("properties", out JsonElement properties)
                                 && properties.ValueKind is JsonValueKind.Object
                                 && schema.TryGetProperty("required", out JsonElement required)
                                 && required.ValueKind is JsonValueKind.Array
                             )
                             {
+                                // Preserve all top-level schema keywords (e.g. $defs, definitions,
+                                // description, title) so $ref references remain resolvable; only
+                                // override type/additionalProperties to satisfy API requirements.
+                                var schemaDict = new Dictionary<string, JsonElement>(
+                                    StringComparer.Ordinal
+                                );
+                                foreach (JsonProperty p in schema.EnumerateObject())
+                                {
+                                    schemaDict[p.Name] = p.Value;
+                                }
+                                schemaDict["type"] = JsonElement.Parse("\"object\"");
+                                schemaDict["additionalProperties"] = JsonElement.Parse("false");
+
                                 createParams = createParams with
                                 {
                                     OutputConfig = (
@@ -1122,15 +1136,7 @@ public static class AnthropicBetaClientExtensions
                                     {
                                         Format = new BetaJsonOutputFormat()
                                         {
-                                            Schema = new Dictionary<string, JsonElement>
-                                            {
-                                                ["type"] = JsonElement.Parse("\"object\""),
-                                                ["properties"] = properties,
-                                                ["required"] = required,
-                                                ["additionalProperties"] = JsonElement.Parse(
-                                                    "false"
-                                                ),
-                                            },
+                                            Schema = schemaDict,
                                         },
                                     },
                                 };

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1115,7 +1115,7 @@ public static class AnthropicBetaClientExtensions
                                 && required.ValueKind is JsonValueKind.Array
                             )
                             {
-                                // Preserve all top-level schema keywords (e.g. $defs, definitions,
+                                // Preserve all top-level schema keywords (e.g. $defs,
                                 // description, title) so $ref references remain resolvable; only
                                 // override type/additionalProperties to satisfy API requirements.
                                 var schemaDict = new Dictionary<string, JsonElement>(


### PR DESCRIPTION
Fixes #195.

## Summary

When converting `ChatResponseFormatJson` to `OutputConfig.Format.JsonOutputFormat.Schema`, the previous code constructed a new dictionary with only four keys (`type`, `properties`, `required`, `additionalProperties`), silently dropping every other top-level JSON Schema keyword — notably `$defs` and `definitions`, which Anthropic's structured-outputs API explicitly supports for internal `$ref` resolution ([docs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)).

For schemas that use `$ref` to reference internal `$defs`, the request was rejected by the server with:

```
HTTP 400 — AnthropicBadRequestException
{"type":"error","error":{"type":"invalid_request_error",
 "message":"output_config.format.schema: Invalid schema:
            Reference to non-existent definition: #/$defs/..."}}
```

## Fix

Preserve all top-level keywords of the transformed schema and only override `type` and `additionalProperties` to satisfy API requirements:

```csharp
var schemaDict = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
foreach (JsonProperty p in schema.EnumerateObject())
{
    schemaDict[p.Name] = p.Value;
}
schemaDict["type"] = JsonElement.Parse("\"object\"");
schemaDict["additionalProperties"] = JsonElement.Parse("false");
```

This is a strict super-set of the current behavior for schemas without `$defs`.

## Test

Added `GetResponseAsync_WithResponseFormatSchemaContainingDefs_PreservesDefs` which verifies that a schema with `$defs` round-trips through the adapter intact to `output_config.format.schema`.

All 180 existing `AnthropicClientExtensions` tests still pass.
