### PR TITLE
fix: streaming parallel tool-use emit logic (issue #197)

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -3061,6 +3061,87 @@ public abstract class AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetStreamingResponseAsync_WithOverlappingParallelToolBlocks_EmitsOneCompleteFunctionCallPerBlock()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Call overlapping parallel tools"
+                    }]
+                }],
+                "stream": true
+            }
+            """,
+            actualResponse: """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_overlap_01","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_a","name":"tool_a","input":{},"caller":{"type":"direct"}}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"arg\":\"a\"}"}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_b","name":"tool_b","input":{},"caller":{"type":"direct"}}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"arg\":\"b\"}"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":1}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":15}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (
+            var update in chatClient.GetStreamingResponseAsync(
+                "Call overlapping parallel tools",
+                new(),
+                TestContext.Current.CancellationToken
+            )
+        )
+        {
+            updates.Add(update);
+        }
+
+        var allFunctionCalls = updates
+            .SelectMany(u => u.Contents.OfType<FunctionCallContent>())
+            .ToList();
+
+        Assert.Equal(2, allFunctionCalls.Count);
+        Assert.Equal(2, allFunctionCalls.Select(fc => fc.CallId).Distinct().Count());
+
+        var fccA = allFunctionCalls.Single(fc => fc.CallId == "toolu_a");
+        Assert.Equal("tool_a", fccA.Name);
+        Assert.NotNull(fccA.Arguments);
+        Assert.Equal("a", fccA.Arguments["arg"]?.ToString());
+        
+        var fccB = allFunctionCalls.Single(fc => fc.CallId == "toolu_b");
+        Assert.Equal("tool_b", fccB.Name);
+        Assert.NotNull(fccB.Arguments);
+        Assert.Equal("b", fccB.Arguments["arg"]?.ToString());
+    }
+
+    [Fact]
     public async Task GetResponseAsync_WithAdditionalUsageCounts()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -3134,7 +3134,7 @@ public abstract class AnthropicClientExtensionsTestsBase
         Assert.Equal("tool_a", fccA.Name);
         Assert.NotNull(fccA.Arguments);
         Assert.Equal("a", fccA.Arguments["arg"]?.ToString());
-        
+
         var fccB = allFunctionCalls.Single(fc => fc.CallId == "toolu_b");
         Assert.Equal("tool_b", fccB.Name);
         Assert.NotNull(fccB.Arguments);

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -766,14 +766,16 @@ public static class AnthropicClientExtensions
                         break;
 
                     case RawContentBlockStopEvent contentBlockStop:
-                        if (streamingFunctions is not null)
+                        if (
+                            streamingFunctions is not null
+                            && streamingFunctions.TryGetValue(
+                                contentBlockStop.Index,
+                                out StreamingFunctionData? completedFunction
+                            )
+                        )
                         {
-                            foreach (var sf in streamingFunctions)
-                            {
-                                contents.Add(CreateStreamingToolCallContent(sf.Value));
-                            }
-
-                            streamingFunctions.Clear();
+                            contents.Add(CreateStreamingToolCallContent(completedFunction));
+                            streamingFunctions.Remove(contentBlockStop.Index);
                         }
                         break;
                 }

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -491,14 +491,16 @@ public static class AnthropicBetaClientExtensions
                         break;
 
                     case BetaRawContentBlockStopEvent contentBlockStop:
-                        if (streamingFunctions is not null)
+                        if (
+                            streamingFunctions is not null
+                            && streamingFunctions.TryGetValue(
+                                contentBlockStop.Index,
+                                out StreamingFunctionData? completedFunction
+                            )
+                        )
                         {
-                            foreach (var sf in streamingFunctions)
-                            {
-                                contents.Add(CreateStreamingToolCallContent(sf.Value));
-                            }
-
-                            streamingFunctions.Clear();
+                            contents.Add(CreateStreamingToolCallContent(completedFunction));
+                            streamingFunctions.Remove(contentBlockStop.Index);
                         }
                         break;
                 }


### PR DESCRIPTION
RawContentBlockStopEvent was iterating over the entire streamingFunctions dictionary and clearing it. When a later tool_use block's content_block_start arrived before an earlier block's content_block_stop, the stop event would emit FunctionCallContent for every tracked tool, **including ones whose input_json deltas had not yet arrived**, and then wipe the dictionary, losing the later tools' real arguments.

Only emit (and remove) the entry whose index matches the stop event, in both AnthropicClientExtensions and AnthropicBetaClientExtensions. Add a regression test in AnthropicClientExtensionsTestsBase so coverage applies to both client variants.

Fixes #197 