### PR TITLE
Handle [DONE] terminal event in SSE streams from Azure APIM hosted Anthropic models

### DIFF
--- a/src/Anthropic.Tests/SseTest.cs
+++ b/src/Anthropic.Tests/SseTest.cs
@@ -223,7 +223,7 @@ public class SseTest : TestBase
     [Fact]
     public async Task Sse_SkipsDoneTerminalEvent()
     {
-        // Microsoft Foundry sends "data: [DONE]" (without an event: field) after
+        // Azure APIM may send "data: [DONE]" (without an event: field) after
         // message_stop to signal end-of-stream. SseParser assigns it the default
         // EventType "message", which matches the deserialization case. Without the
         // [DONE] guard this would throw a JsonException.
@@ -262,7 +262,7 @@ public class SseTest : TestBase
         }
 
         // Should have received 6 events (start, block_start, delta, block_stop, message_delta, message_stop)
-        // and NOT thrown on [DONE]
+        // and NOT throw on [DONE]
         Assert.Equal(6, actualMessages.Count);
     }
 }

--- a/src/Anthropic.Tests/SseTest.cs
+++ b/src/Anthropic.Tests/SseTest.cs
@@ -219,4 +219,50 @@ public class SseTest : TestBase
         Assert.IsType<AnthropicServiceException>(sseEx, exactMatch: false);
         Assert.Equal(ErrorType.OverloadedError, sseEx.ErrorType);
     }
+
+    [Fact]
+    public async Task Sse_SkipsDoneTerminalEvent()
+    {
+        // Microsoft Foundry sends "data: [DONE]" (without an event: field) after
+        // message_stop to signal end-of-stream. SseParser assigns it the default
+        // EventType "message", which matches the deserialization case. Without the
+        // [DONE] guard this would throw a JsonException.
+        var events = """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            data: [DONE]
+
+
+            """;
+
+        var resp = new HttpResponseMessage() { Content = new StringContent(events) };
+
+        var actualMessages = new List<JsonElement>();
+        await foreach (
+            var message in Sse.Enumerate<JsonElement>(resp, TestContext.Current.CancellationToken)
+        )
+        {
+            actualMessages.Add(message);
+        }
+
+        // Should have received 6 events (start, block_start, delta, block_stop, message_delta, message_stop)
+        // and NOT thrown on [DONE]
+        Assert.Equal(6, actualMessages.Count);
+    }
 }

--- a/src/Anthropic/Core/Sse.cs
+++ b/src/Anthropic/Core/Sse.cs
@@ -72,6 +72,13 @@ static class Sse
                 case "session.thread_status_rescheduled":
                 case "session.thread_status_terminated":
                 case "system.message":
+                    if (item.Data == "[DONE]")
+                    {
+                        // This is a terminal event sent by Microsoft Foundry to indicate the
+                        // end of the stream. It should not be treated as a message and should
+                        // not be deserialized.
+                        continue;
+                    }
                     T? message;
                     try
                     {

--- a/src/Anthropic/Core/Sse.cs
+++ b/src/Anthropic/Core/Sse.cs
@@ -74,9 +74,9 @@ static class Sse
                 case "system.message":
                     if (item.Data == "[DONE]")
                     {
-                        // This is a terminal event sent by Microsoft Foundry to indicate the
-                        // end of the stream. It should not be treated as a message and should
-                        // not be deserialized.
+                        // This is a terminal event that may be sent by Azure APIM to 
+                        // indicate the end of the stream. It should not be treated as
+                        // a message and should not be deserialized.
                         continue;
                     }
                     T? message;


### PR DESCRIPTION
Added a guard for `data: [DONE]` SSE terminal event emitted by Microsoft Foundry during SSE streams.  Without this guard, the SSE parser assigns a default `EventType` of `"message"` to such events, causing the SDK to attempt JSON deserialization on the literal string `"[DONE]"`. This results in a `JsonException` ('D' is an invalid start of a value).

Test case:
`dotnet test src/Anthropic.Tests/Anthropic.Tests.csproj --filter "SseTest.Sse_SkipsDoneTerminalEvent"`

Previous exception seen with Anthropic model usage on Microsoft Foundry using streaming chat completion through Microsoft.Extensions.AI:
```
ERROR|Microsoft.Extensions.AI.LoggingChatClient|GetStreamingResponseAsync failed. Anthropic.Exceptions.AnthropicInvalidDataException: Message must be of type Anthropic.Models.Messages.RawMessageStreamEvent
 ---> System.Text.Json.JsonException: 'D' is an invalid start of a value. Path: $ | LineNumber: 0 | BytePositionInLine: 1.
 ---> System.Text.Json.JsonReaderException: 'D' is an invalid start of a value. LineNumber: 0 | BytePositionInLine: 1.
   at System.Text.Json.ThrowHelper.ThrowJsonReaderException(Utf8JsonReader& json, ExceptionResource resource, Byte nextByte, ReadOnlySpan`1 bytes)
   at System.Text.Json.Utf8JsonReader.ConsumeValue(Byte marker)
   at System.Text.Json.Utf8JsonReader.ReadSingleSegment()
   at System.Text.Json.JsonSerializer.GetReaderScopedToNextValue(Utf8JsonReader& reader, ReadStack& state)
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, JsonReaderException ex)
   at System.Text.Json.JsonSerializer.GetReaderScopedToNextValue(Utf8JsonReader& reader, ReadStack& state)
   at System.Text.Json.JsonSerializer.Read[TValue](Utf8JsonReader& reader, JsonTypeInfo`1 jsonTypeInfo)
   at Anthropic.Models.Messages.RawMessageStreamEventConverter.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options) in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/Models/Messages/RawMessageStreamEvent.cs:line 415
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 json, JsonTypeInfo`1 jsonTypeInfo)
   at Anthropic.Core.Sse.Enumerate[T](HttpResponseMessage response, CancellationToken cancellationToken)+MoveNext()
   --- End of inner exception stack trace ---
   at Anthropic.Core.Sse.Enumerate[T](HttpResponseMessage response, CancellationToken cancellationToken)+MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/Core/Sse.cs:line 82
   at Anthropic.Core.Sse.Enumerate[T](HttpResponseMessage response, CancellationToken cancellationToken)+MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/Core/Sse.cs:line 26
   at Anthropic.Core.Sse.Enumerate[T](HttpResponseMessage response, CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at Anthropic.Services.MessageServiceWithRawResponse.<>c__DisplayClass7_0.<<CreateStreaming>g__Enumerate|2>d.MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/Services/MessageService.cs:line 200
--- End of stack trace from previous location ---
   at Anthropic.Services.MessageServiceWithRawResponse.<>c__DisplayClass7_0.<<CreateStreaming>g__Enumerate|2>d.MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/Services/MessageService.cs:line 200
--- End of stack trace from previous location ---
   at Anthropic.Services.MessageServiceWithRawResponse.<>c__DisplayClass7_0.<<CreateStreaming>g__Enumerate|2>d.System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult(Int16 token)
   at Anthropic.Core.StreamingHttpResponse`1.Enumerate(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/Core/HttpResponse.cs:line 188
   at Anthropic.Core.StreamingHttpResponse`1.Enumerate(CancellationToken cancellationToken)+MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/Core/HttpResponse.cs:line 188
   at Anthropic.Core.StreamingHttpResponse`1.Enumerate(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at Anthropic.Services.MessageService.CreateStreaming(MessageCreateParams parameters, CancellationToken cancellationToken)+MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/Services/MessageService.cs:line 69
   at Anthropic.Services.MessageService.CreateStreaming(MessageCreateParams parameters, CancellationToken cancellationToken)+MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/Services/MessageService.cs:line 69
   at Anthropic.Services.MessageService.CreateStreaming(MessageCreateParams parameters, CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at Microsoft.Extensions.AI.AnthropicClientExtensions.AnthropicChatClient.GetStreamingResponseAsync(IEnumerable`1 messages, ChatOptions options, CancellationToken cancellationToken)+MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/AnthropicClientExtensions.cs:line 598
   at Microsoft.Extensions.AI.AnthropicClientExtensions.AnthropicChatClient.GetStreamingResponseAsync(IEnumerable`1 messages, ChatOptions options, CancellationToken cancellationToken)+MoveNext() in /home/runner/work/anthropic-sdk-csharp/anthropic-sdk-csharp/src/Anthropic/AnthropicClientExtensions.cs:line 598
   at Microsoft.Extensions.AI.AnthropicClientExtensions.AnthropicChatClient.GetStreamingResponseAsync(IEnumerable`1 messages, ChatOptions options, CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at Microsoft.Extensions.AI.FunctionInvokingChatClient.GetStreamingResponseAsync(IEnumerable`1 messages, ChatOptions options, CancellationToken cancellationToken)+MoveNext()
   at Microsoft.Extensions.AI.FunctionInvokingChatClient.GetStreamingResponseAsync(IEnumerable`1 messages, ChatOptions options, CancellationToken cancellationToken)+MoveNext()
   at Microsoft.Extensions.AI.FunctionInvokingChatClient.GetStreamingResponseAsync(IEnumerable`1 messages, ChatOptions options, CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at Microsoft.Extensions.AI.LoggingChatClient.GetStreamingResponseAsync(IEnumerable`1 messages, ChatOptions options, CancellationToken cancellationToken)+MoveNext()
```