### PR TITLE
fix: emit only the completed tool in streaming content_block_stop handler

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -3061,6 +3061,90 @@ public abstract class AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetStreamingResponseAsync_WithParallelToolCalls_EmitsOnlyAtOwnStopEvent()
+    {
+        // Regression test: when tool A stops while tool B still has pending deltas,
+        // only tool A should be emitted — not both.
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Call parallel tools"
+                    }]
+                }],
+                "stream": true
+            }
+            """,
+            actualResponse: """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_par_01","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_fast","name":"get_weather","input":{},"caller":{"type":"direct"}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_slow","name":"search_db","input":{},"caller":{"type":"direct"}}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Berlin\"}"}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"table\":"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"users\",\"limit\":50}"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":1}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":20}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (
+            var update in chatClient.GetStreamingResponseAsync(
+                "Call parallel tools",
+                new(),
+                TestContext.Current.CancellationToken
+            )
+        )
+        {
+            updates.Add(update);
+        }
+
+        var allFunctionCalls = updates
+            .SelectMany(u => u.Contents.OfType<FunctionCallContent>())
+            .ToList();
+
+        Assert.Equal(2, allFunctionCalls.Count);
+
+        var weatherCall = allFunctionCalls.Single(fc => fc.CallId == "toolu_fast");
+        Assert.Equal("get_weather", weatherCall.Name);
+        Assert.Equal("Berlin", weatherCall.Arguments?["city"]?.ToString());
+
+        var dbCall = allFunctionCalls.Single(fc => fc.CallId == "toolu_slow");
+        Assert.Equal("search_db", dbCall.Name);
+        Assert.Equal("users", dbCall.Arguments?["table"]?.ToString());
+        Assert.Equal("50", dbCall.Arguments?["limit"]?.ToString());
+    }
+
+    [Fact]
     public async Task GetResponseAsync_WithAdditionalUsageCounts()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -766,14 +766,17 @@ public static class AnthropicClientExtensions
                         break;
 
                     case RawContentBlockStopEvent contentBlockStop:
-                        if (streamingFunctions is not null)
+                        if (
+                            streamingFunctions is not null
+                            && streamingFunctions.Remove(
+                                contentBlockStop.Index,
+                                out StreamingFunctionData? completedFunction
+                            )
+                        )
                         {
-                            foreach (var sf in streamingFunctions)
-                            {
-                                contents.Add(CreateStreamingToolCallContent(sf.Value));
-                            }
-
-                            streamingFunctions.Clear();
+                            contents.Add(
+                                CreateStreamingToolCallContent(completedFunction)
+                            );
                         }
                         break;
                 }

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -491,14 +491,17 @@ public static class AnthropicBetaClientExtensions
                         break;
 
                     case BetaRawContentBlockStopEvent contentBlockStop:
-                        if (streamingFunctions is not null)
+                        if (
+                            streamingFunctions is not null
+                            && streamingFunctions.Remove(
+                                contentBlockStop.Index,
+                                out StreamingFunctionData? completedFunction
+                            )
+                        )
                         {
-                            foreach (var sf in streamingFunctions)
-                            {
-                                contents.Add(CreateStreamingToolCallContent(sf.Value));
-                            }
-
-                            streamingFunctions.Clear();
+                            contents.Add(
+                                CreateStreamingToolCallContent(completedFunction)
+                            );
                         }
                         break;
                 }


### PR DESCRIPTION
## Summary

Fixes #197 — `GetStreamingResponseAsync` emits duplicate/incomplete `FunctionCallContent` when multiple tools are called in parallel.

### Root cause

`RawContentBlockStopEvent` iterates **all** entries in `streamingFunctions` and clears the dictionary on every `content_block_stop` event. When tools are called in parallel:

1. The first `content_block_stop` emits every tracked tool — including those still receiving `input_json_delta` chunks — with potentially incomplete arguments
2. Subsequent `content_block_stop` events find an empty dictionary and emit nothing
3. `FunctionInvokingChatClient` constructs a response with duplicate `tool_use` ids, causing the API to reject with `"tool_use ids must be unique"`

### Fix

Replace the `foreach` + `Clear()` with a targeted `Dictionary.Remove()` at `contentBlockStop.Index`. Each tool is now emitted exactly once, only when its own stop event fires, with fully accumulated arguments.

The same fix is applied to the Beta streaming path in `AnthropicBetaClientExtensions.cs`.

### Test

Added `GetStreamingResponseAsync_WithParallelToolCalls_EmitsOnlyAtOwnStopEvent` — a regression test where one tool's `content_block_stop` fires while another tool still has pending `input_json_delta` chunks. This test fails on `main` and passes with the fix.

## Test plan

- [x] New regression test covers the exact interleaving scenario from the issue
- [x] All existing streaming tool call tests pass (sequential, interleaved, fragmented, parameterless, server tool use)
- [x] Full test suite: 9269 passed, 0 regressions (52 pre-existing failures are API connectivity tests)