### PR TITLE
fix: preserve $defs and $ref in ChatResponseFormatJson schema mapping

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -6161,6 +6161,112 @@ public abstract class AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetResponseAsync_WithDefsRefSchema_PreservesDefinitions()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-sonnet-4-5-20250929",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Return a result"
+                    }]
+                }],
+                "output_config": {
+                    "format": {
+                        "type": "json_schema",
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "segments": {
+                                    "type": "array",
+                                    "items": { "$ref": "#/$defs/Segment" }
+                                }
+                            },
+                            "required": ["segments"],
+                            "$defs": {
+                                "Segment": {
+                                    "type": "object",
+                                    "properties": {
+                                        "label": { "type": "string" },
+                                        "value": { "type": "integer" }
+                                    },
+                                    "required": ["label", "value"]
+                                }
+                            },
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_defs_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-sonnet-4-5-20250929",
+                "content": [{
+                    "type": "text",
+                    "text": "{\"segments\":[{\"label\":\"A\",\"value\":1}]}"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 20,
+                    "output_tokens": 10
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-sonnet-4-5-20250929");
+
+        ChatOptions options = new()
+        {
+            ResponseFormat = ChatResponseFormat.ForJsonSchema(
+                JsonElement.Parse(
+                    """
+                    {
+                        "type": "object",
+                        "properties": {
+                            "segments": {
+                                "type": "array",
+                                "items": { "$ref": "#/$defs/Segment" }
+                            }
+                        },
+                        "required": ["segments"],
+                        "$defs": {
+                            "Segment": {
+                                "type": "object",
+                                "properties": {
+                                    "label": { "type": "string" },
+                                    "value": { "type": "integer" }
+                                },
+                                "required": ["label", "value"]
+                            }
+                        }
+                    }
+                    """
+                ),
+                "SegmentResult"
+            ),
+        };
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            "Return a result",
+            options,
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.NotNull(response);
+        TextContent textContent = Assert.IsType<TextContent>(response.Messages[0].Contents[0]);
+        Assert.Contains("segments", textContent.Text);
+    }
+
+    [Fact]
     public async Task GetResponseAsync_WithNestedObjectSchema_ReturnsStructuredJSON()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -1263,12 +1263,22 @@ public static class AnthropicClientExtensions
                                 .GetOrCreateTransformedSchema(formatJson)
                                 .GetValueOrDefault();
                             if (
-                                schema.TryGetProperty("properties", out JsonElement properties)
-                                && properties.ValueKind is JsonValueKind.Object
-                                && schema.TryGetProperty("required", out JsonElement required)
-                                && required.ValueKind is JsonValueKind.Array
+                                schema.TryGetProperty("properties", out _)
+                                && schema.TryGetProperty("required", out _)
                             )
                             {
+                                var schemaDict = new Dictionary<string, JsonElement>();
+                                foreach (JsonProperty p in schema.EnumerateObject())
+                                {
+                                    schemaDict[p.Name] = p.Value;
+                                }
+
+                                schemaDict.TryAdd("type", JsonElement.Parse("\"object\""));
+                                schemaDict.TryAdd(
+                                    "additionalProperties",
+                                    JsonElement.Parse("false")
+                                );
+
                                 createParams = createParams with
                                 {
                                     OutputConfig = (
@@ -1277,15 +1287,7 @@ public static class AnthropicClientExtensions
                                     {
                                         Format = new JsonOutputFormat()
                                         {
-                                            Schema = new Dictionary<string, JsonElement>
-                                            {
-                                                ["type"] = JsonElement.Parse("\"object\""),
-                                                ["properties"] = properties,
-                                                ["required"] = required,
-                                                ["additionalProperties"] = JsonElement.Parse(
-                                                    "false"
-                                                ),
-                                            },
+                                            Schema = schemaDict,
                                         },
                                     },
                                 };

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -1108,12 +1108,22 @@ public static class AnthropicBetaClientExtensions
                                 .JsonSchemaTransformCache.GetOrCreateTransformedSchema(formatJson)
                                 .GetValueOrDefault();
                             if (
-                                schema.TryGetProperty("properties", out JsonElement properties)
-                                && properties.ValueKind is JsonValueKind.Object
-                                && schema.TryGetProperty("required", out JsonElement required)
-                                && required.ValueKind is JsonValueKind.Array
+                                schema.TryGetProperty("properties", out _)
+                                && schema.TryGetProperty("required", out _)
                             )
                             {
+                                var schemaDict = new Dictionary<string, JsonElement>();
+                                foreach (JsonProperty p in schema.EnumerateObject())
+                                {
+                                    schemaDict[p.Name] = p.Value;
+                                }
+
+                                schemaDict.TryAdd("type", JsonElement.Parse("\"object\""));
+                                schemaDict.TryAdd(
+                                    "additionalProperties",
+                                    JsonElement.Parse("false")
+                                );
+
                                 createParams = createParams with
                                 {
                                     OutputConfig = (
@@ -1122,15 +1132,7 @@ public static class AnthropicBetaClientExtensions
                                     {
                                         Format = new BetaJsonOutputFormat()
                                         {
-                                            Schema = new Dictionary<string, JsonElement>
-                                            {
-                                                ["type"] = JsonElement.Parse("\"object\""),
-                                                ["properties"] = properties,
-                                                ["required"] = required,
-                                                ["additionalProperties"] = JsonElement.Parse(
-                                                    "false"
-                                                ),
-                                            },
+                                            Schema = schemaDict,
                                         },
                                     },
                                 };


### PR DESCRIPTION
## Summary

Fixes #195 — `AnthropicChatClient` drops `$defs` / `$ref` when forwarding `ChatResponseFormatJson.Schema` to `OutputConfig.Format`, causing `HTTP 400 — Reference to non-existent definition`.

### Root cause

The `OutputConfig.Format.Schema` dictionary was constructed with only four hardcoded keys:

```csharp
Schema = new Dictionary<string, JsonElement>
{
    ["type"] = ...,
    ["properties"] = properties,
    ["required"] = required,
    ["additionalProperties"] = ...,
}
```

Any other top-level JSON Schema keywords — most notably `$defs` — were silently stripped. Schemas that use `$ref` to reference internal `$defs` (which [Anthropic's structured outputs explicitly supports](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)) were then rejected by the server.

### Fix

Iterate all properties from the already-transformed schema (which the `JsonSchemaTransformCache` has already filtered to only supported keywords) and copy them into the dictionary. Then `TryAdd` `type` and `additionalProperties` as defaults if not already present.

This preserves `$defs`, `$ref`, `anyOf`, `allOf`, and any future keywords the transform cache allows through. The same fix is applied to the Beta path in `AnthropicBetaClientExtensions.cs`.

### Test

Added `GetResponseAsync_WithDefsRefSchema_PreservesDefinitions` — verifies that a schema using `$defs`/`$ref` round-trips correctly through the `VerbatimHttpHandler` (exact JSON match against expected API request).

## Test plan

- [x] New test verifies `$defs`/`$ref` schema is forwarded to the API
- [x] All existing schema tests pass (simple, nested, enum, all-transformations)
- [x] Full test suite: 9269 passed, 0 regressions (52 pre-existing failures are API connectivity tests)