### PR TITLE
fix(client): preserve cache token counts when message_delta omits them

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -5227,6 +5227,80 @@ public abstract class AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetStreamingResponseAsync_DeltaWithoutCacheTokens_PreservesStartCacheTokens()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "hello"
+                    }]
+                }],
+                "stream": true
+            }
+            """,
+            // message_start reports cache tokens, but the terminal message_delta omits the
+            // cache_* fields (as the API typically does). The cache counts from message_start
+            // must be preserved instead of being wiped out by the delta.
+            actualResponse: """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":8,"cache_creation_input_tokens":50,"cache_read_input_tokens":25,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":8,"output_tokens":12}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (
+            var update in chatClient.GetStreamingResponseAsync(
+                "hello",
+                new(),
+                TestContext.Current.CancellationToken
+            )
+        )
+        {
+            updates.Add(update);
+        }
+
+        Assert.NotEmpty(updates);
+        var usageContent = updates
+            .SelectMany(u => u.Contents.OfType<UsageContent>())
+            .LastOrDefault();
+        Assert.NotNull(usageContent);
+
+        // Cache token counts from message_start survive the cache-less message_delta.
+        Assert.Equal(25, usageContent.Details.CachedInputTokenCount);
+        Assert.NotNull(usageContent.Details.AdditionalCounts);
+        Assert.Equal(50L, usageContent.Details.AdditionalCounts["CacheCreationInputTokens"]);
+
+        // input_tokens (8) + cache_creation (50) + cache_read (25) = 83.
+        Assert.Equal(83, usageContent.Details.InputTokenCount);
+        Assert.Equal(12, usageContent.Details.OutputTokenCount);
+        Assert.Equal(95, usageContent.Details.TotalTokenCount);
+    }
+
+    [Fact]
     public async Task GetResponseAsync_FunctionResult_WithSingleTextContent()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -3061,6 +3061,87 @@ public abstract class AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetStreamingResponseAsync_WithOverlappingParallelToolBlocks_EmitsOneCompleteFunctionCallPerBlock()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Call overlapping parallel tools"
+                    }]
+                }],
+                "stream": true
+            }
+            """,
+            actualResponse: """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_overlap_01","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_a","name":"tool_a","input":{},"caller":{"type":"direct"}}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"arg\":\"a\"}"}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_b","name":"tool_b","input":{},"caller":{"type":"direct"}}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"arg\":\"b\"}"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":1}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":15}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (
+            var update in chatClient.GetStreamingResponseAsync(
+                "Call overlapping parallel tools",
+                new(),
+                TestContext.Current.CancellationToken
+            )
+        )
+        {
+            updates.Add(update);
+        }
+
+        var allFunctionCalls = updates
+            .SelectMany(u => u.Contents.OfType<FunctionCallContent>())
+            .ToList();
+
+        Assert.Equal(2, allFunctionCalls.Count);
+        Assert.Equal(2, allFunctionCalls.Select(fc => fc.CallId).Distinct().Count());
+
+        var fccA = allFunctionCalls.Single(fc => fc.CallId == "toolu_a");
+        Assert.Equal("tool_a", fccA.Name);
+        Assert.NotNull(fccA.Arguments);
+        Assert.Equal("a", fccA.Arguments["arg"]?.ToString());
+
+        var fccB = allFunctionCalls.Single(fc => fc.CallId == "toolu_b");
+        Assert.Equal("tool_b", fccB.Name);
+        Assert.NotNull(fccB.Arguments);
+        Assert.Equal("b", fccB.Arguments["arg"]?.ToString());
+    }
+
+    [Fact]
     public async Task GetResponseAsync_WithAdditionalUsageCounts()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -5308,6 +5308,80 @@ public abstract class AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetStreamingResponseAsync_DeltaWithoutCacheTokens_PreservesStartCacheTokens()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "hello"
+                    }]
+                }],
+                "stream": true
+            }
+            """,
+            // message_start reports cache tokens, but the terminal message_delta omits the
+            // cache_* fields (as the API typically does). The cache counts from message_start
+            // must be preserved instead of being wiped out by the delta.
+            actualResponse: """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":8,"cache_creation_input_tokens":50,"cache_read_input_tokens":25,"output_tokens":0}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":8,"output_tokens":12}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (
+            var update in chatClient.GetStreamingResponseAsync(
+                "hello",
+                new(),
+                TestContext.Current.CancellationToken
+            )
+        )
+        {
+            updates.Add(update);
+        }
+
+        Assert.NotEmpty(updates);
+        var usageContent = updates
+            .SelectMany(u => u.Contents.OfType<UsageContent>())
+            .LastOrDefault();
+        Assert.NotNull(usageContent);
+
+        // Cache token counts from message_start survive the cache-less message_delta.
+        Assert.Equal(25, usageContent.Details.CachedInputTokenCount);
+        Assert.NotNull(usageContent.Details.AdditionalCounts);
+        Assert.Equal(50L, usageContent.Details.AdditionalCounts["CacheCreationInputTokens"]);
+
+        // input_tokens (8) + cache_creation (50) + cache_read (25) = 83.
+        Assert.Equal(83, usageContent.Details.InputTokenCount);
+        Assert.Equal(12, usageContent.Details.OutputTokenCount);
+        Assert.Equal(95, usageContent.Details.TotalTokenCount);
+    }
+
+    [Fact]
     public async Task GetResponseAsync_FunctionResult_WithSingleTextContent()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -635,7 +635,10 @@ public static class AnthropicClientExtensions
                         {
                             // https://platform.claude.com/docs/en/build-with-claude/streaming
                             // "The token counts shown in the usage field of the message_delta event are cumulative."
-                            usageDetails = ToUsageDetails(deltaUsage);
+                            // The cache token fields are nullable and are usually omitted on the
+                            // terminal message_delta, so merge them with the values already
+                            // populated from message_start instead of replacing wholesale.
+                            usageDetails = ToUsageDetails(deltaUsage, usageDetails);
                         }
                         break;
 
@@ -1541,6 +1544,27 @@ public static class AnthropicClientExtensions
                 usage.CacheReadInputTokens,
                 usage.ServerToolUse
             );
+
+        private static UsageDetails ToUsageDetails(
+            MessageDeltaUsage usage,
+            UsageDetails? previous
+        ) =>
+            // The cache token fields on message_delta are nullable and usually omitted on the
+            // terminal event. Fall back to the values already populated from message_start so
+            // the cached token counts are not wiped out (mirrors MessageContentAggregator).
+            ToUsageDetails(
+                usage.InputTokens,
+                usage.OutputTokens,
+                usage.CacheCreationInputTokens ?? GetCacheCreationInputTokens(previous),
+                usage.CacheReadInputTokens ?? previous?.CachedInputTokenCount,
+                usage.ServerToolUse
+            );
+
+        private static long? GetCacheCreationInputTokens(UsageDetails? usageDetails) =>
+            usageDetails?.AdditionalCounts is { } counts
+            && counts.TryGetValue(nameof(Usage.CacheCreationInputTokens), out long value)
+                ? value
+                : null;
 
         private static UsageDetails ToUsageDetails(
             long? inputTokens,

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -766,14 +766,16 @@ public static class AnthropicClientExtensions
                         break;
 
                     case RawContentBlockStopEvent contentBlockStop:
-                        if (streamingFunctions is not null)
+                        if (
+                            streamingFunctions is not null
+                            && streamingFunctions.TryGetValue(
+                                contentBlockStop.Index,
+                                out StreamingFunctionData? completedFunction
+                            )
+                        )
                         {
-                            foreach (var sf in streamingFunctions)
-                            {
-                                contents.Add(CreateStreamingToolCallContent(sf.Value));
-                            }
-
-                            streamingFunctions.Clear();
+                            contents.Add(CreateStreamingToolCallContent(completedFunction));
+                            streamingFunctions.Remove(contentBlockStop.Index);
                         }
                         break;
                 }

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -591,6 +591,12 @@ public static class AnthropicClientExtensions
             string? messageId = null;
             string? modelID = null;
             UsageDetails? usageDetails = null;
+            // The cache/input token fields are nullable and are usually omitted on the terminal
+            // message_delta, so remember the values reported on message_start to fall back on.
+            long? startInputTokens = null;
+            long? startCacheCreationInputTokens = null;
+            long? startCacheReadInputTokens = null;
+            ServerToolUsage? startServerToolUse = null;
             ChatFinishReason? finishReason = null;
             Dictionary<long, StreamingFunctionData>? streamingFunctions = null;
 
@@ -617,6 +623,10 @@ public static class AnthropicClientExtensions
 
                         if (rawMessageStart.Message.Usage is { } usage)
                         {
+                            startInputTokens = usage.InputTokens;
+                            startCacheCreationInputTokens = usage.CacheCreationInputTokens;
+                            startCacheReadInputTokens = usage.CacheReadInputTokens;
+                            startServerToolUse = usage.ServerToolUse;
                             UsageDetails current = ToUsageDetails(usage);
                             if (usageDetails is null)
                             {
@@ -635,10 +645,17 @@ public static class AnthropicClientExtensions
                         {
                             // https://platform.claude.com/docs/en/build-with-claude/streaming
                             // "The token counts shown in the usage field of the message_delta event are cumulative."
-                            // The cache token fields are nullable and are usually omitted on the
-                            // terminal message_delta, so merge them with the values already
-                            // populated from message_start instead of replacing wholesale.
-                            usageDetails = ToUsageDetails(deltaUsage, usageDetails);
+                            // These fields are nullable and usually omitted on the terminal
+                            // message_delta, so fall back to the message_start values instead of
+                            // wiping them out.
+                            usageDetails = ToUsageDetails(
+                                deltaUsage.InputTokens ?? startInputTokens,
+                                deltaUsage.OutputTokens,
+                                deltaUsage.CacheCreationInputTokens
+                                    ?? startCacheCreationInputTokens,
+                                deltaUsage.CacheReadInputTokens ?? startCacheReadInputTokens,
+                                deltaUsage.ServerToolUse ?? startServerToolUse
+                            );
                         }
                         break;
 
@@ -1535,36 +1552,6 @@ public static class AnthropicClientExtensions
                 usage.CacheReadInputTokens,
                 usage.ServerToolUse
             );
-
-        private static UsageDetails ToUsageDetails(MessageDeltaUsage usage) =>
-            ToUsageDetails(
-                usage.InputTokens,
-                usage.OutputTokens,
-                usage.CacheCreationInputTokens,
-                usage.CacheReadInputTokens,
-                usage.ServerToolUse
-            );
-
-        private static UsageDetails ToUsageDetails(
-            MessageDeltaUsage usage,
-            UsageDetails? previous
-        ) =>
-            // The cache token fields on message_delta are nullable and usually omitted on the
-            // terminal event. Fall back to the values already populated from message_start so
-            // the cached token counts are not wiped out (mirrors MessageContentAggregator).
-            ToUsageDetails(
-                usage.InputTokens,
-                usage.OutputTokens,
-                usage.CacheCreationInputTokens ?? GetCacheCreationInputTokens(previous),
-                usage.CacheReadInputTokens ?? previous?.CachedInputTokenCount,
-                usage.ServerToolUse
-            );
-
-        private static long? GetCacheCreationInputTokens(UsageDetails? usageDetails) =>
-            usageDetails?.AdditionalCounts is { } counts
-            && counts.TryGetValue(nameof(Usage.CacheCreationInputTokens), out long value)
-                ? value
-                : null;
 
         private static UsageDetails ToUsageDetails(
             long? inputTokens,

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -635,7 +635,10 @@ public static class AnthropicClientExtensions
                         {
                             // https://platform.claude.com/docs/en/build-with-claude/streaming
                             // "The token counts shown in the usage field of the message_delta event are cumulative."
-                            usageDetails = ToUsageDetails(deltaUsage);
+                            // The cache token fields are nullable and are usually omitted on the
+                            // terminal message_delta, so merge them with the values already
+                            // populated from message_start instead of replacing wholesale.
+                            usageDetails = ToUsageDetails(deltaUsage, usageDetails);
                         }
                         break;
 
@@ -1543,6 +1546,27 @@ public static class AnthropicClientExtensions
                 usage.CacheReadInputTokens,
                 usage.ServerToolUse
             );
+
+        private static UsageDetails ToUsageDetails(
+            MessageDeltaUsage usage,
+            UsageDetails? previous
+        ) =>
+            // The cache token fields on message_delta are nullable and usually omitted on the
+            // terminal event. Fall back to the values already populated from message_start so
+            // the cached token counts are not wiped out (mirrors MessageContentAggregator).
+            ToUsageDetails(
+                usage.InputTokens,
+                usage.OutputTokens,
+                usage.CacheCreationInputTokens ?? GetCacheCreationInputTokens(previous),
+                usage.CacheReadInputTokens ?? previous?.CachedInputTokenCount,
+                usage.ServerToolUse
+            );
+
+        private static long? GetCacheCreationInputTokens(UsageDetails? usageDetails) =>
+            usageDetails?.AdditionalCounts is { } counts
+            && counts.TryGetValue(nameof(Usage.CacheCreationInputTokens), out long value)
+                ? value
+                : null;
 
         private static UsageDetails ToUsageDetails(
             long? inputTokens,

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -591,6 +591,12 @@ public static class AnthropicClientExtensions
             string? messageId = null;
             string? modelID = null;
             UsageDetails? usageDetails = null;
+            // The cache/input token fields are nullable and are usually omitted on the terminal
+            // message_delta, so remember the values reported on message_start to fall back on.
+            long? startInputTokens = null;
+            long? startCacheCreationInputTokens = null;
+            long? startCacheReadInputTokens = null;
+            ServerToolUsage? startServerToolUse = null;
             ChatFinishReason? finishReason = null;
             Dictionary<long, StreamingFunctionData>? streamingFunctions = null;
 
@@ -617,6 +623,10 @@ public static class AnthropicClientExtensions
 
                         if (rawMessageStart.Message.Usage is { } usage)
                         {
+                            startInputTokens = usage.InputTokens;
+                            startCacheCreationInputTokens = usage.CacheCreationInputTokens;
+                            startCacheReadInputTokens = usage.CacheReadInputTokens;
+                            startServerToolUse = usage.ServerToolUse;
                             UsageDetails current = ToUsageDetails(usage);
                             if (usageDetails is null)
                             {
@@ -635,10 +645,17 @@ public static class AnthropicClientExtensions
                         {
                             // https://platform.claude.com/docs/en/build-with-claude/streaming
                             // "The token counts shown in the usage field of the message_delta event are cumulative."
-                            // The cache token fields are nullable and are usually omitted on the
-                            // terminal message_delta, so merge them with the values already
-                            // populated from message_start instead of replacing wholesale.
-                            usageDetails = ToUsageDetails(deltaUsage, usageDetails);
+                            // These fields are nullable and usually omitted on the terminal
+                            // message_delta, so fall back to the message_start values instead of
+                            // wiping them out.
+                            usageDetails = ToUsageDetails(
+                                deltaUsage.InputTokens ?? startInputTokens,
+                                deltaUsage.OutputTokens,
+                                deltaUsage.CacheCreationInputTokens
+                                    ?? startCacheCreationInputTokens,
+                                deltaUsage.CacheReadInputTokens ?? startCacheReadInputTokens,
+                                deltaUsage.ServerToolUse ?? startServerToolUse
+                            );
                         }
                         break;
 
@@ -1537,36 +1554,6 @@ public static class AnthropicClientExtensions
                 usage.CacheReadInputTokens,
                 usage.ServerToolUse
             );
-
-        private static UsageDetails ToUsageDetails(MessageDeltaUsage usage) =>
-            ToUsageDetails(
-                usage.InputTokens,
-                usage.OutputTokens,
-                usage.CacheCreationInputTokens,
-                usage.CacheReadInputTokens,
-                usage.ServerToolUse
-            );
-
-        private static UsageDetails ToUsageDetails(
-            MessageDeltaUsage usage,
-            UsageDetails? previous
-        ) =>
-            // The cache token fields on message_delta are nullable and usually omitted on the
-            // terminal event. Fall back to the values already populated from message_start so
-            // the cached token counts are not wiped out (mirrors MessageContentAggregator).
-            ToUsageDetails(
-                usage.InputTokens,
-                usage.OutputTokens,
-                usage.CacheCreationInputTokens ?? GetCacheCreationInputTokens(previous),
-                usage.CacheReadInputTokens ?? previous?.CachedInputTokenCount,
-                usage.ServerToolUse
-            );
-
-        private static long? GetCacheCreationInputTokens(UsageDetails? usageDetails) =>
-            usageDetails?.AdditionalCounts is { } counts
-            && counts.TryGetValue(nameof(Usage.CacheCreationInputTokens), out long value)
-                ? value
-                : null;
 
         private static UsageDetails ToUsageDetails(
             long? inputTokens,

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -358,7 +358,10 @@ public static class AnthropicBetaClientExtensions
                         {
                             // https://platform.claude.com/docs/en/build-with-claude/streaming
                             // "The token counts shown in the usage field of the message_delta event are cumulative."
-                            usageDetails = ToUsageDetails(deltaUsage);
+                            // The cache token fields are nullable and are usually omitted on the
+                            // terminal message_delta, so merge them with the values already
+                            // populated from message_start instead of replacing wholesale.
+                            usageDetails = ToUsageDetails(deltaUsage, usageDetails);
                         }
                         break;
 
@@ -1464,6 +1467,27 @@ public static class AnthropicBetaClientExtensions
                 usage.CacheReadInputTokens,
                 usage.ServerToolUse
             );
+
+        private static UsageDetails ToUsageDetails(
+            BetaMessageDeltaUsage usage,
+            UsageDetails? previous
+        ) =>
+            // The cache token fields on message_delta are nullable and usually omitted on the
+            // terminal event. Fall back to the values already populated from message_start so
+            // the cached token counts are not wiped out (mirrors MessageContentAggregator).
+            ToUsageDetails(
+                usage.InputTokens,
+                usage.OutputTokens,
+                usage.CacheCreationInputTokens ?? GetCacheCreationInputTokens(previous),
+                usage.CacheReadInputTokens ?? previous?.CachedInputTokenCount,
+                usage.ServerToolUse
+            );
+
+        private static long? GetCacheCreationInputTokens(UsageDetails? usageDetails) =>
+            usageDetails?.AdditionalCounts is { } counts
+            && counts.TryGetValue(nameof(BetaUsage.CacheCreationInputTokens), out long value)
+                ? value
+                : null;
 
         private static UsageDetails ToUsageDetails(
             long? inputTokens,

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -314,6 +314,12 @@ public static class AnthropicBetaClientExtensions
             string? messageId = null;
             string? modelID = null;
             UsageDetails? usageDetails = null;
+            // The cache/input token fields are nullable and are usually omitted on the terminal
+            // message_delta, so remember the values reported on message_start to fall back on.
+            long? startInputTokens = null;
+            long? startCacheCreationInputTokens = null;
+            long? startCacheReadInputTokens = null;
+            BetaServerToolUsage? startServerToolUse = null;
             ChatFinishReason? finishReason = null;
             Dictionary<long, StreamingFunctionData>? streamingFunctions = null;
 
@@ -340,6 +346,10 @@ public static class AnthropicBetaClientExtensions
 
                         if (rawMessageStart.Message.Usage is { } usage)
                         {
+                            startInputTokens = usage.InputTokens;
+                            startCacheCreationInputTokens = usage.CacheCreationInputTokens;
+                            startCacheReadInputTokens = usage.CacheReadInputTokens;
+                            startServerToolUse = usage.ServerToolUse;
                             UsageDetails current = ToUsageDetails(usage);
                             if (usageDetails is null)
                             {
@@ -358,10 +368,17 @@ public static class AnthropicBetaClientExtensions
                         {
                             // https://platform.claude.com/docs/en/build-with-claude/streaming
                             // "The token counts shown in the usage field of the message_delta event are cumulative."
-                            // The cache token fields are nullable and are usually omitted on the
-                            // terminal message_delta, so merge them with the values already
-                            // populated from message_start instead of replacing wholesale.
-                            usageDetails = ToUsageDetails(deltaUsage, usageDetails);
+                            // These fields are nullable and usually omitted on the terminal
+                            // message_delta, so fall back to the message_start values instead of
+                            // wiping them out.
+                            usageDetails = ToUsageDetails(
+                                deltaUsage.InputTokens ?? startInputTokens,
+                                deltaUsage.OutputTokens,
+                                deltaUsage.CacheCreationInputTokens
+                                    ?? startCacheCreationInputTokens,
+                                deltaUsage.CacheReadInputTokens ?? startCacheReadInputTokens,
+                                deltaUsage.ServerToolUse ?? startServerToolUse
+                            );
                         }
                         break;
 
@@ -1460,36 +1477,6 @@ public static class AnthropicBetaClientExtensions
                 usage.CacheReadInputTokens,
                 usage.ServerToolUse
             );
-
-        private static UsageDetails ToUsageDetails(BetaMessageDeltaUsage usage) =>
-            ToUsageDetails(
-                usage.InputTokens,
-                usage.OutputTokens,
-                usage.CacheCreationInputTokens,
-                usage.CacheReadInputTokens,
-                usage.ServerToolUse
-            );
-
-        private static UsageDetails ToUsageDetails(
-            BetaMessageDeltaUsage usage,
-            UsageDetails? previous
-        ) =>
-            // The cache token fields on message_delta are nullable and usually omitted on the
-            // terminal event. Fall back to the values already populated from message_start so
-            // the cached token counts are not wiped out (mirrors MessageContentAggregator).
-            ToUsageDetails(
-                usage.InputTokens,
-                usage.OutputTokens,
-                usage.CacheCreationInputTokens ?? GetCacheCreationInputTokens(previous),
-                usage.CacheReadInputTokens ?? previous?.CachedInputTokenCount,
-                usage.ServerToolUse
-            );
-
-        private static long? GetCacheCreationInputTokens(UsageDetails? usageDetails) =>
-            usageDetails?.AdditionalCounts is { } counts
-            && counts.TryGetValue(nameof(BetaUsage.CacheCreationInputTokens), out long value)
-                ? value
-                : null;
 
         private static UsageDetails ToUsageDetails(
             long? inputTokens,

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -491,14 +491,16 @@ public static class AnthropicBetaClientExtensions
                         break;
 
                     case BetaRawContentBlockStopEvent contentBlockStop:
-                        if (streamingFunctions is not null)
+                        if (
+                            streamingFunctions is not null
+                            && streamingFunctions.TryGetValue(
+                                contentBlockStop.Index,
+                                out StreamingFunctionData? completedFunction
+                            )
+                        )
                         {
-                            foreach (var sf in streamingFunctions)
-                            {
-                                contents.Add(CreateStreamingToolCallContent(sf.Value));
-                            }
-
-                            streamingFunctions.Clear();
+                            contents.Add(CreateStreamingToolCallContent(completedFunction));
+                            streamingFunctions.Remove(contentBlockStop.Index);
                         }
                         break;
                 }

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -314,6 +314,12 @@ public static class AnthropicBetaClientExtensions
             string? messageId = null;
             string? modelID = null;
             UsageDetails? usageDetails = null;
+            // The cache/input token fields are nullable and are usually omitted on the terminal
+            // message_delta, so remember the values reported on message_start to fall back on.
+            long? startInputTokens = null;
+            long? startCacheCreationInputTokens = null;
+            long? startCacheReadInputTokens = null;
+            BetaServerToolUsage? startServerToolUse = null;
             ChatFinishReason? finishReason = null;
             Dictionary<long, StreamingFunctionData>? streamingFunctions = null;
 
@@ -340,6 +346,10 @@ public static class AnthropicBetaClientExtensions
 
                         if (rawMessageStart.Message.Usage is { } usage)
                         {
+                            startInputTokens = usage.InputTokens;
+                            startCacheCreationInputTokens = usage.CacheCreationInputTokens;
+                            startCacheReadInputTokens = usage.CacheReadInputTokens;
+                            startServerToolUse = usage.ServerToolUse;
                             UsageDetails current = ToUsageDetails(usage);
                             if (usageDetails is null)
                             {
@@ -358,10 +368,17 @@ public static class AnthropicBetaClientExtensions
                         {
                             // https://platform.claude.com/docs/en/build-with-claude/streaming
                             // "The token counts shown in the usage field of the message_delta event are cumulative."
-                            // The cache token fields are nullable and are usually omitted on the
-                            // terminal message_delta, so merge them with the values already
-                            // populated from message_start instead of replacing wholesale.
-                            usageDetails = ToUsageDetails(deltaUsage, usageDetails);
+                            // These fields are nullable and usually omitted on the terminal
+                            // message_delta, so fall back to the message_start values instead of
+                            // wiping them out.
+                            usageDetails = ToUsageDetails(
+                                deltaUsage.InputTokens ?? startInputTokens,
+                                deltaUsage.OutputTokens,
+                                deltaUsage.CacheCreationInputTokens
+                                    ?? startCacheCreationInputTokens,
+                                deltaUsage.CacheReadInputTokens ?? startCacheReadInputTokens,
+                                deltaUsage.ServerToolUse ?? startServerToolUse
+                            );
                         }
                         break;
 
@@ -1458,36 +1475,6 @@ public static class AnthropicBetaClientExtensions
                 usage.CacheReadInputTokens,
                 usage.ServerToolUse
             );
-
-        private static UsageDetails ToUsageDetails(BetaMessageDeltaUsage usage) =>
-            ToUsageDetails(
-                usage.InputTokens,
-                usage.OutputTokens,
-                usage.CacheCreationInputTokens,
-                usage.CacheReadInputTokens,
-                usage.ServerToolUse
-            );
-
-        private static UsageDetails ToUsageDetails(
-            BetaMessageDeltaUsage usage,
-            UsageDetails? previous
-        ) =>
-            // The cache token fields on message_delta are nullable and usually omitted on the
-            // terminal event. Fall back to the values already populated from message_start so
-            // the cached token counts are not wiped out (mirrors MessageContentAggregator).
-            ToUsageDetails(
-                usage.InputTokens,
-                usage.OutputTokens,
-                usage.CacheCreationInputTokens ?? GetCacheCreationInputTokens(previous),
-                usage.CacheReadInputTokens ?? previous?.CachedInputTokenCount,
-                usage.ServerToolUse
-            );
-
-        private static long? GetCacheCreationInputTokens(UsageDetails? usageDetails) =>
-            usageDetails?.AdditionalCounts is { } counts
-            && counts.TryGetValue(nameof(BetaUsage.CacheCreationInputTokens), out long value)
-                ? value
-                : null;
 
         private static UsageDetails ToUsageDetails(
             long? inputTokens,

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -358,7 +358,10 @@ public static class AnthropicBetaClientExtensions
                         {
                             // https://platform.claude.com/docs/en/build-with-claude/streaming
                             // "The token counts shown in the usage field of the message_delta event are cumulative."
-                            usageDetails = ToUsageDetails(deltaUsage);
+                            // The cache token fields are nullable and are usually omitted on the
+                            // terminal message_delta, so merge them with the values already
+                            // populated from message_start instead of replacing wholesale.
+                            usageDetails = ToUsageDetails(deltaUsage, usageDetails);
                         }
                         break;
 
@@ -1466,6 +1469,27 @@ public static class AnthropicBetaClientExtensions
                 usage.CacheReadInputTokens,
                 usage.ServerToolUse
             );
+
+        private static UsageDetails ToUsageDetails(
+            BetaMessageDeltaUsage usage,
+            UsageDetails? previous
+        ) =>
+            // The cache token fields on message_delta are nullable and usually omitted on the
+            // terminal event. Fall back to the values already populated from message_start so
+            // the cached token counts are not wiped out (mirrors MessageContentAggregator).
+            ToUsageDetails(
+                usage.InputTokens,
+                usage.OutputTokens,
+                usage.CacheCreationInputTokens ?? GetCacheCreationInputTokens(previous),
+                usage.CacheReadInputTokens ?? previous?.CachedInputTokenCount,
+                usage.ServerToolUse
+            );
+
+        private static long? GetCacheCreationInputTokens(UsageDetails? usageDetails) =>
+            usageDetails?.AdditionalCounts is { } counts
+            && counts.TryGetValue(nameof(BetaUsage.CacheCreationInputTokens), out long value)
+                ? value
+                : null;
 
         private static UsageDetails ToUsageDetails(
             long? inputTokens,


### PR DESCRIPTION
## Summary

The Microsoft.Extensions.AI streaming bridge loses the prompt-caching token counts reported by `message_start` whenever the terminal `message_delta` omits the cache fields (which is the common case).

In both `AsIChatClient` bridges the `message_delta` handler replaced the accumulated usage wholesale:

```csharp
usageDetails = ToUsageDetails(deltaUsage);
```

`MessageDeltaUsage.CacheReadInputTokens` and `CacheCreationInputTokens` are nullable and are usually absent on `message_delta`. `ToUsageDetails` maps those nulls straight through, so the cache counts populated from `message_start` are wiped out: `CachedInputTokenCount` becomes `null` and `InputTokenCount`/`TotalTokenCount` are understated.

## Root cause

- `src/Anthropic/AnthropicClientExtensions.cs` (`RawMessageDeltaEvent` handler, ~line 638)
- `src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs` (`BetaRawMessageDeltaEvent` handler, ~line 361)

## Fix

Replace the wholesale assignment with a per-field, null-safe merge: only the delta's non-null cache values override what `message_start` already populated; when the delta omits a cache field, the existing value is kept and the derived input/total counts are recomputed accordingly.

This mirrors how the SDK already merges streaming usage elsewhere:
- `src/Anthropic/Helpers/MessageContentAggregator.cs` (null-checked overwrite of `CacheCreationInputTokens`/`CacheReadInputTokens`, lines ~70-80)
- `FallbackStreamSplicer.Backfill` (`src/Anthropic/Helpers/FallbackStreamSplicer.cs`, ~line 889)

## Test

Added `GetStreamingResponseAsync_DeltaWithoutCacheTokens_PreservesStartCacheTokens` to `AnthropicClientExtensionsTestsBase` (so it runs for both the standard and Beta bridges). It streams a `message_start` carrying cache tokens followed by a `message_delta` that omits the cache fields, and asserts the final usage still reports `CachedInputTokenCount`, `CacheCreationInputTokens`, and the correct `InputTokenCount`/`TotalTokenCount`.

These are hand-written bridge files (not generated), so the change is local to them.