### PR TITLE
fix(helpers): rewrap delta.Usage.Iterations to BetaUsageIteration

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "src/Anthropic": "12.29.1",
+  "src/Anthropic": "12.30.0",
   "src/Anthropic.Foundry": "0.7.0",
   "src/Anthropic.Bedrock": "0.10.1",
   "src/Anthropic.Vertex": "0.5.0",

--- a/src/Anthropic.Tests/Helpers/BetaRefusalFallbackHandlerStreamingTest.cs
+++ b/src/Anthropic.Tests/Helpers/BetaRefusalFallbackHandlerStreamingTest.cs
@@ -962,9 +962,9 @@ public class BetaRefusalFallbackHandlerStreamingTest
         Assert.NotNull(message.Usage.OutputTokensDetails);
         var iterations = message.Usage.Iterations!;
         Assert.Equal(2, iterations.Count);
-        Assert.True(iterations[0].TryPickMessageIterationUsage(out var refused));
+        Assert.True(iterations[0].TryPickBetaMessageIterationUsage(out var refused));
         Assert.Equal(FableModel, refused!.Model.Raw());
-        Assert.True(iterations[1].TryPickFallbackMessageIterationUsage(out var served));
+        Assert.True(iterations[1].TryPickBetaFallbackMessageIterationUsage(out var served));
         Assert.Equal(FallbackModel, served!.Model.Raw());
     }
 

--- a/src/Anthropic/Anthropic.csproj
+++ b/src/Anthropic/Anthropic.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Anthropic C#</AssemblyTitle>
     <AssemblyName>Anthropic</AssemblyName>
     <PackageId>Anthropic</PackageId>
-    <VersionPrefix>12.29.1</VersionPrefix>
+    <VersionPrefix>12.30.0</VersionPrefix>
     <StainlessMainProject>true</StainlessMainProject>
     <Description>The official .NET library for the Anthropic API.</Description>
     <OutputType>Library</OutputType>

--- a/src/Anthropic/CHANGELOG.md
+++ b/src/Anthropic/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 12.30.0 (2026-06-18)
+
+Full Changelog: [Anthropic-v12.29.1...Anthropic-v12.30.0](https://github.com/anthropics/anthropic-sdk-csharp/compare/Anthropic-v12.29.1...Anthropic-v12.30.0)
+
+### Features
+
+* **api:** add support for new code_execution_20260120 tool ([7943727](https://github.com/anthropics/anthropic-sdk-csharp/commit/794372758fb03b41da3699b4ac0fa75322497f1d))
+
+
+### Bug Fixes
+
+* **client:** bad model definitions ([050cd3c](https://github.com/anthropics/anthropic-sdk-csharp/commit/050cd3ccf48ac843dd334175606c226820722623))
+
 ## 12.29.1 (2026-06-15)
 
 Full Changelog: [Anthropic-v12.29.0...Anthropic-v12.29.1](https://github.com/anthropics/anthropic-sdk-csharp/compare/Anthropic-v12.29.0...Anthropic-v12.29.1)

--- a/src/Anthropic/Helpers/BetaMessageContentAggregator.cs
+++ b/src/Anthropic/Helpers/BetaMessageContentAggregator.cs
@@ -108,7 +108,16 @@ public sealed class BetaMessageContentAggregator
                 // the latest delta supersedes prior values.
                 if (delta.Usage.Iterations != null)
                 {
-                    usage = usage with { Iterations = delta.Usage.Iterations };
+                    // BetaMessageDeltaUsage.Iterations and BetaUsage.Iterations are the
+                    // same union schema but the generator currently inlines them under two
+                    // distinct C# types (Iteration / BetaUsageIteration); rewrap via the
+                    // raw JSON until the shared type is restored upstream.
+                    usage = usage with
+                    {
+                        Iterations = delta
+                            .Usage.Iterations.Select(i => new BetaUsageIteration(i.Json))
+                            .ToList(),
+                    };
                 }
             }
         }

--- a/src/Anthropic/Helpers/BetaMessageContentAggregator.cs
+++ b/src/Anthropic/Helpers/BetaMessageContentAggregator.cs
@@ -114,9 +114,10 @@ public sealed class BetaMessageContentAggregator
                     // raw JSON until the shared type is restored upstream.
                     usage = usage with
                     {
-                        Iterations = delta
-                            .Usage.Iterations.Select(i => new BetaUsageIteration(i.Json))
-                            .ToList(),
+                        Iterations =
+                        [
+                            .. delta.Usage.Iterations.Select(i => new BetaUsageIteration(i.Json)),
+                        ],
                     };
                 }
             }

--- a/src/Anthropic/Helpers/BetaMessageContentAggregator.cs
+++ b/src/Anthropic/Helpers/BetaMessageContentAggregator.cs
@@ -116,7 +116,18 @@ public sealed class BetaMessageContentAggregator
                     {
                         Iterations =
                         [
-                            .. delta.Usage.Iterations.Select(i => new BetaUsageIteration(i.Json)),
+                            .. delta.Usage.Iterations.Select(i =>
+                                i.Value switch
+                                {
+                                    BetaMessageIterationUsage v => new BetaUsageIteration(v),
+                                    BetaCompactionIterationUsage v => new BetaUsageIteration(v),
+                                    BetaAdvisorMessageIterationUsage v => new BetaUsageIteration(v),
+                                    BetaFallbackMessageIterationUsage v => new BetaUsageIteration(
+                                        v
+                                    ),
+                                    _ => new BetaUsageIteration(i.Json),
+                                }
+                            ),
                         ],
                     };
                 }


### PR DESCRIPTION
The C# generator (since commit 050cd3cc) inlines the `iterations` union under two distinct types — `Iteration` on `BetaMessageDeltaUsage` vs `BetaUsageIteration` on `BetaUsage` — and renamed the variant accessors to `TryPickBeta*`. Both reference the same schema; the shared `BetaIterationsUsageItems` type was deleted by the generator (same spec+config hash → generator behavior change).

- Rewrap `delta.Usage.Iterations` via raw `JsonElement` in the aggregator
- Update the streaming test to the new `TryPickBeta*` method names

Unblocks the release PR (#216). The shared-type restoration is a Stainless-side fix.