### PR TITLE
docs(changelog): detail the beta files/skills GA-shape change

### DIFF
--- a/src/Anthropic/CHANGELOG.md
+++ b/src/Anthropic/CHANGELOG.md
@@ -8,12 +8,12 @@ Full Changelog: [Anthropic-v12.43.0...Anthropic-v12.44.0](https://github.com/ant
 
 * **api:** beta files/skills namespaces use GA shapes; drop dated beta header pins ([6e61d8f](https://github.com/anthropics/anthropic-sdk-csharp/commit/6e61d8f21991d30dfa1a5b8ded486f107b1b84cc))
 
-  The beta Files and Skills namespaces no longer send the `files-api-2025-04-14` / `skills-2025-10-02` headers and return the same shapes as `client.files` / `client.skills` (with `Beta`-prefixed type names). Requests that still send those headers on raw HTTP keep receiving the beta shapes.
+  The beta Files and Skills services (`client.Beta.Files`, `client.Beta.Skills`) no longer send the `files-api-2025-04-14` / `skills-2025-10-02` headers and return the same shapes as `client.Files` / `client.Skills` (with `Beta`-prefixed model type names under `Anthropic.Models.Beta`). Requests that still send those headers on raw HTTP keep receiving the beta shapes.
 
-  Changes in the beta namespaces:
-  - `client.beta.skills.delete()` now deletes a Skill together with all of its versions (previously refused while any version existed).
-  - Beta Messages type `BetaSkill` (container skill reference, `{type, skill_id, version}`) is renamed `BetaContainerSkill`; `BetaSkill` now names the Skills resource.
-  - `client.beta.files.list()` returns `{data, next_page}` and paginates with `page` / `ids` (was `{data, has_more, first_id, last_id}` with `before_id` / `after_id`); Skills types use `display_name`, `latest_version_id`, and `skver_…` version ids.
+  Changes in the beta services:
+  - `client.Beta.Skills.Delete()` now deletes a Skill together with all of its versions (previously refused while any version existed). It returns `BetaDeletedSkill` (was `SkillDeleteResponse`).
+  - Beta Messages type `Anthropic.Models.Beta.Messages.BetaSkill` (container skill reference with `SkillID`, `Type`, `Version`) is renamed `BetaContainerSkill`; the request-side `BetaSkillParams` keeps its name. `BetaSkill` now names the Skill object `Anthropic.Models.Beta.Skills.BetaSkill` returned by `client.Beta.Skills.Create()` / `Retrieve()` / `List()` (replacing `SkillCreateResponse` / `SkillRetrieveResponse` / `SkillListResponse`), and skill versions are `BetaSkillVersion` / `BetaDeletedSkillVersion` (replacing `Version*Response`).
+  - `client.Beta.Files.List()` returns a `FileListPage` over a `FileListPageResponse` with `Data` and `NextPage`, and `FileListParams` paginates with `Page` / `Ids` (was `Data`, `HasMore`, `FirstID`, `LastID` with `BeforeID` / `AfterID`); `Paginate()` is unchanged, and `SkillListPageResponse` / `VersionListPageResponse` drop `HasMore`. `BetaSkill` uses `DisplayName` (was `DisplayTitle`, also on `SkillCreateParams`) and `LatestVersionID` (was `LatestVersion`), and `BetaSkillVersion` is addressed by its `skver_…` `ID` (the Unix-timestamp `Version` property is gone).
 
   Migration guides: [Migrate from `files-api-2025-04-14`](https://platform.claude.com/docs/en/build-with-claude/files#migrate-from-files-api-2025-04-14) · [Migrate from `skills-2025-10-02`](https://platform.claude.com/docs/en/build-with-claude/skills-guide#migrate-from-skills-2025-10-02)
 

--- a/src/Anthropic/CHANGELOG.md
+++ b/src/Anthropic/CHANGELOG.md
@@ -8,6 +8,15 @@ Full Changelog: [Anthropic-v12.43.0...Anthropic-v12.44.0](https://github.com/ant
 
 * **api:** beta files/skills namespaces use GA shapes; drop dated beta header pins ([6e61d8f](https://github.com/anthropics/anthropic-sdk-csharp/commit/6e61d8f21991d30dfa1a5b8ded486f107b1b84cc))
 
+  The beta Files and Skills namespaces no longer send the `files-api-2025-04-14` / `skills-2025-10-02` headers and return the same shapes as `client.files` / `client.skills` (with `Beta`-prefixed type names). Requests that still send those headers on raw HTTP keep receiving the beta shapes.
+
+  Changes in the beta namespaces:
+  - `client.beta.skills.delete()` now deletes a Skill together with all of its versions (previously refused while any version existed).
+  - Beta Messages type `BetaSkill` (container skill reference, `{type, skill_id, version}`) is renamed `BetaContainerSkill`; `BetaSkill` now names the Skills resource.
+  - `client.beta.files.list()` returns `{data, next_page}` and paginates with `page` / `ids` (was `{data, has_more, first_id, last_id}` with `before_id` / `after_id`); Skills types use `display_name`, `latest_version_id`, and `skver_…` version ids.
+
+  Migration guides: [Migrate from `files-api-2025-04-14`](https://platform.claude.com/docs/en/build-with-claude/files#migrate-from-files-api-2025-04-14) · [Migrate from `skills-2025-10-02`](https://platform.claude.com/docs/en/build-with-claude/skills-guide#migrate-from-skills-2025-10-02)
+
 
 ### Bug Fixes
 


### PR DESCRIPTION
Expands the `beta files/skills namespaces use GA shapes; drop dated beta header pins` changelog entry with what changed in the beta namespaces and links to the migration guides.