### PR TITLE
fix(meai): populate UsageDetails.ReasoningTokenCount from output_tokens_details.thinking_tokens

### DIFF
--- a/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
+++ b/src/Anthropic.Tests/AnthropicClientExtensionsTestsBase.cs
@@ -6570,6 +6570,120 @@ public abstract class AnthropicClientExtensionsTestsBase
     }
 
     [Fact]
+    public async Task GetResponseAsync_WithThinkingTokens_PopulatesReasoningTokenCount()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "Test with thinking"
+                    }]
+                }],
+                "max_tokens": 1024
+            }
+            """,
+            actualResponse: """
+            {
+                "id": "msg_thinking_01",
+                "type": "message",
+                "role": "assistant",
+                "model": "claude-haiku-4-5",
+                "content": [{
+                    "type": "text",
+                    "text": "Response"
+                }],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 40,
+                    "output_tokens_details": {
+                        "thinking_tokens": 30
+                    }
+                }
+            }
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        ChatResponse response = await chatClient.GetResponseAsync(
+            "Test with thinking",
+            new(),
+            TestContext.Current.CancellationToken
+        );
+
+        Assert.NotNull(response.Usage);
+        Assert.Equal(40, response.Usage.OutputTokenCount);
+        Assert.Equal(30, response.Usage.ReasoningTokenCount);
+    }
+
+    [Fact]
+    public async Task GetStreamingResponseAsync_ThinkingTokensFromDelta_PopulateReasoningTokenCount()
+    {
+        VerbatimHttpHandler handler = new(
+            expectedRequest: """
+            {
+                "max_tokens": 1024,
+                "model": "claude-haiku-4-5",
+                "messages": [{
+                    "role": "user",
+                    "content": [{
+                        "type": "text",
+                        "text": "hello"
+                    }]
+                }],
+                "stream": true
+            }
+            """,
+            actualResponse: """
+            event: message_start
+            data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":8,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":1,"output_tokens_details":{"thinking_tokens":0}}}}
+
+            event: content_block_start
+            data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+            event: content_block_delta
+            data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello!"}}
+
+            event: content_block_stop
+            data: {"type":"content_block_stop","index":0}
+
+            event: message_delta
+            data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":42,"output_tokens_details":{"thinking_tokens":25}}}
+
+            event: message_stop
+            data: {"type":"message_stop"}
+
+            """
+        );
+
+        IChatClient chatClient = CreateChatClient(handler, "claude-haiku-4-5");
+
+        List<ChatResponseUpdate> updates = [];
+        await foreach (
+            var update in chatClient.GetStreamingResponseAsync(
+                "hello",
+                new(),
+                TestContext.Current.CancellationToken
+            )
+        )
+        {
+            updates.Add(update);
+        }
+
+        var usageContent = updates
+            .SelectMany(u => u.Contents.OfType<UsageContent>())
+            .LastOrDefault();
+        Assert.NotNull(usageContent);
+        Assert.Equal(42, usageContent.Details.OutputTokenCount);
+        Assert.Equal(25, usageContent.Details.ReasoningTokenCount);
+    }
+
+    [Fact]
     public async Task GetStreamingResponseAsync_DeltaWithoutCacheTokens_PreservesStartCacheTokens()
     {
         VerbatimHttpHandler handler = new(

--- a/src/Anthropic/AnthropicClientExtensions.cs
+++ b/src/Anthropic/AnthropicClientExtensions.cs
@@ -683,6 +683,7 @@ public static class AnthropicClientExtensions
             long? startCacheCreationInputTokens = null;
             long? startCacheReadInputTokens = null;
             ServerToolUsage? startServerToolUse = null;
+            long? startThinkingTokens = null;
             ChatFinishReason? finishReason = null;
             Dictionary<long, StreamingFunctionData>? streamingFunctions = null;
 
@@ -713,6 +714,7 @@ public static class AnthropicClientExtensions
                             startCacheCreationInputTokens = usage.CacheCreationInputTokens;
                             startCacheReadInputTokens = usage.CacheReadInputTokens;
                             startServerToolUse = usage.ServerToolUse;
+                            startThinkingTokens = usage.OutputTokensDetails?.ThinkingTokens;
                             UsageDetails current = ToUsageDetails(usage);
                             if (usageDetails is null)
                             {
@@ -740,7 +742,9 @@ public static class AnthropicClientExtensions
                                 deltaUsage.CacheCreationInputTokens
                                     ?? startCacheCreationInputTokens,
                                 deltaUsage.CacheReadInputTokens ?? startCacheReadInputTokens,
-                                deltaUsage.ServerToolUse ?? startServerToolUse
+                                deltaUsage.ServerToolUse ?? startServerToolUse,
+                                deltaUsage.OutputTokensDetails?.ThinkingTokens
+                                    ?? startThinkingTokens
                             );
                         }
                         break;
@@ -1812,7 +1816,8 @@ public static class AnthropicClientExtensions
                 usage.OutputTokens,
                 usage.CacheCreationInputTokens,
                 usage.CacheReadInputTokens,
-                usage.ServerToolUse
+                usage.ServerToolUse,
+                usage.OutputTokensDetails?.ThinkingTokens
             );
 
         private static UsageDetails ToUsageDetails(
@@ -1820,7 +1825,8 @@ public static class AnthropicClientExtensions
             long? outputTokens,
             long? cacheCreationInputTokens,
             long? cacheReadInputTokens,
-            ServerToolUsage? serverToolUsage
+            ServerToolUsage? serverToolUsage,
+            long? thinkingTokens
         )
         {
             UsageDetails usageDetails = new()
@@ -1836,6 +1842,10 @@ public static class AnthropicClientExtensions
                 CachedInputTokenCount = cacheReadInputTokens,
 
                 OutputTokenCount = outputTokens,
+
+                // thinking_tokens is a subset of output_tokens, which is what
+                // UsageDetails.ReasoningTokenCount is documented to count.
+                ReasoningTokenCount = thinkingTokens,
             };
 
             usageDetails.TotalTokenCount = NullableSum(

--- a/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
+++ b/src/Anthropic/Services/Beta/Messages/AnthropicBetaClientExtensions.cs
@@ -372,6 +372,7 @@ public static class AnthropicBetaClientExtensions
             long? startCacheCreationInputTokens = null;
             long? startCacheReadInputTokens = null;
             BetaServerToolUsage? startServerToolUse = null;
+            long? startThinkingTokens = null;
             ChatFinishReason? finishReason = null;
             Dictionary<long, StreamingFunctionData>? streamingFunctions = null;
 
@@ -402,6 +403,7 @@ public static class AnthropicBetaClientExtensions
                             startCacheCreationInputTokens = usage.CacheCreationInputTokens;
                             startCacheReadInputTokens = usage.CacheReadInputTokens;
                             startServerToolUse = usage.ServerToolUse;
+                            startThinkingTokens = usage.OutputTokensDetails?.ThinkingTokens;
                             UsageDetails current = ToUsageDetails(usage);
                             if (usageDetails is null)
                             {
@@ -429,7 +431,9 @@ public static class AnthropicBetaClientExtensions
                                 deltaUsage.CacheCreationInputTokens
                                     ?? startCacheCreationInputTokens,
                                 deltaUsage.CacheReadInputTokens ?? startCacheReadInputTokens,
-                                deltaUsage.ServerToolUse ?? startServerToolUse
+                                deltaUsage.ServerToolUse ?? startServerToolUse,
+                                deltaUsage.OutputTokensDetails?.ThinkingTokens
+                                    ?? startThinkingTokens
                             );
                         }
                         break;
@@ -1696,7 +1700,8 @@ public static class AnthropicBetaClientExtensions
                 usage.OutputTokens,
                 usage.CacheCreationInputTokens,
                 usage.CacheReadInputTokens,
-                usage.ServerToolUse
+                usage.ServerToolUse,
+                usage.OutputTokensDetails?.ThinkingTokens
             );
 
         private static UsageDetails ToUsageDetails(
@@ -1704,7 +1709,8 @@ public static class AnthropicBetaClientExtensions
             long? outputTokens,
             long? cacheCreationInputTokens,
             long? cacheReadInputTokens,
-            BetaServerToolUsage? serverToolUsage
+            BetaServerToolUsage? serverToolUsage,
+            long? thinkingTokens
         )
         {
             UsageDetails usageDetails = new()
@@ -1720,6 +1726,10 @@ public static class AnthropicBetaClientExtensions
                 CachedInputTokenCount = cacheReadInputTokens,
 
                 OutputTokenCount = outputTokens,
+
+                // thinking_tokens is a subset of output_tokens, which is what
+                // UsageDetails.ReasoningTokenCount is documented to count.
+                ReasoningTokenCount = thinkingTokens,
             };
 
             usageDetails.TotalTokenCount = NullableSum(


### PR DESCRIPTION
Fixes #245

## Summary

The Microsoft.Extensions.AI adapters never forward `Usage.OutputTokensDetails.ThinkingTokens`: `ToUsageDetails` (`AnthropicClientExtensions.cs`, and its beta twin) passes input, output, cache-creation, cache-read and server-tool counts into the shared overload and stops there, so a consumer on the `IChatClient` surface cannot meter reasoning tokens even though the response model carries them on both the final `usage` and the cumulative `message_delta` usage.

`UsageDetails.ReasoningTokenCount` exists in the pinned `Microsoft.Extensions.AI.Abstractions` 10.5.1 and is documented as counted within `OutputTokenCount` — the same relationship the API documents for `thinking_tokens` and `output_tokens`, so the mapping is a direct assignment with no arithmetic.

## Change

- `ToUsageDetails(Usage)` / `ToUsageDetails(BetaUsage)` pass `usage.OutputTokensDetails?.ThinkingTokens`; the shared overload takes it as `long? thinkingTokens` and sets `ReasoningTokenCount`.
- Streaming: the `message_start` value is remembered and the `message_delta` path uses `deltaUsage.OutputTokensDetails?.ThinkingTokens ?? startThinkingTokens`, the same fallback the cache-token fields already use so a terminal delta that omits the details does not wipe the count.
- No behaviour change when `output_tokens_details` is absent: `ReasoningTokenCount` stays `null`, as before.

## Tests

Two tests in `AnthropicClientExtensionsTestsBase`, so they run against both adapters: a non-streaming response with `"output_tokens_details": {"thinking_tokens": 30}` → `ReasoningTokenCount == 30`; a stream whose `message_delta` carries `thinking_tokens: 25` → the last `UsageContent` reports 25. With the adapter change reverted all four fail with `Actual: null`. `AnthropicClientExtensionsTests` 249 and `AnthropicClientBetaExtensionsTests` 261 pass on `net8.0`; `csharpier` and `dotnet format` clean.

Assisted by Claude Code.
